### PR TITLE
Replace _WINDOWS by _WIN32

### DIFF
--- a/mz.h
+++ b/mz.h
@@ -147,7 +147,7 @@
 #define MZ_FREE(PTR)                    (free(PTR))
 #endif
 
-#if defined(_WINDOWS) && defined(MZ_EXPORTS)
+#if defined(_WIN32) && defined(MZ_EXPORTS)
 #define MZ_EXPORT __declspec(dllexport)
 #else
 #define MZ_EXPORT

--- a/test/test.c
+++ b/test/test.c
@@ -85,7 +85,7 @@ int32_t test_utf8(void)
     uint8_t *utf8_string = mz_os_utf8_string_create(test_string, MZ_ENCODING_CODEPAGE_950);
     if (utf8_string == NULL)
         return MZ_BUF_ERROR;
-#if defined(_WINDOWS)
+#if defined(_WIN32)
     wchar_t *unicode_string = mz_os_unicode_string_create((const char *)utf8_string, MZ_ENCODING_UTF8);
     if (unicode_string == NULL)
         return MZ_BUF_ERROR;


### PR DESCRIPTION
_WIN32 is commonly used and more supported than _WINDOWS pre definition.

The official predefines supported by Visual Studio are listed here: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160

This PR is related #475, but won't fix that, because only when MZ_COMPAT is enabled that minizip-ng provides external symbols.

/cc @impark @SpaceIm