### PR TITLE
fixing dos_date bugs

### DIFF
--- a/minishared.c
+++ b/minishared.c
@@ -160,7 +160,7 @@ uint32_t tm_to_dosdate(const struct tm *ptm)
     else /* range [00, 79] */
         fixed_tm.tm_year += 20;
 
-    if (invalid_date(ptm))
+    if (invalid_date(&fixed_tm))
         return 0;
 
     return (uint32_t)(((fixed_tm.tm_mday) + (32 * (fixed_tm.tm_mon + 1)) + (512 * fixed_tm.tm_year)) << 16) |

--- a/zip.c
+++ b/zip.c
@@ -974,10 +974,7 @@ extern int ZEXPORT zipOpenNewFileInZip_internal(zipFile file,
     if (zipfi == NULL)
         zi->ci.dos_date = 0;
     else
-    {
-        if (zipfi->dos_date != 0)
-            zi->ci.dos_date = zipfi->dos_date;
-    }
+        zi->ci.dos_date = zipfi->dos_date;
 
     zi->ci.method = method;
     zi->ci.compression_method = method;


### PR DESCRIPTION
The first commit is self-explanatory: After fixing the year offset, we should verify the fixed object, not the original.

The second commit fixes a bug intruduced in [28ad5bf4fb7ceb1014e1d80c9b64ce52bb329329 ](https://github.com/think-cell/minizip-ng/commit/28ad5bf4fb7ceb1014e1d80c9b64ce52bb329329):
- back then, the `tmz_date` member of `zip_fileinfo` was removed (see  [`zip.h`](https://github.com/think-cell/minizip-ng/commit/28ad5bf4fb7ceb1014e1d80c9b64ce52bb329329#diff-da89eb1436a2da88656a727b287191971d66bac1fbf4f975f2d9e9aec5505dd2))
- but before, setting `dos_date` to `0` was a flag to use this member. The code path checking that was removed (see [`zip.c`](https://github.com/think-cell/minizip-ng/commit/28ad5bf4fb7ceb1014e1d80c9b64ce52bb329329#diff-d334166fc820d9710f69cd137d12c36001349b7759e26560c86a90997e4aa694), last change in that file) without noticing that the `dos_date` member of `curfile64_info` (which gets written to disk) would be left uninitialized in that case.