### PR TITLE
Make mz_crypt_openssl.c work with BoringSSL

### DIFF
--- a/mz_crypt_openssl.c
+++ b/mz_crypt_openssl.c
@@ -16,10 +16,19 @@
 #include <openssl/rand.h>
 #include <openssl/sha.h>
 #include <openssl/aes.h>
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
 #include <openssl/hmac.h>
-#include <openssl/pkcs12.h>
+
+#if defined(MZ_ZIP_SIGNING)
+/* Note: https://www.imperialviolet.org/2015/10/17/boringssl.html says that
+   BoringSSL does not support CMS. "#include <etc/cms.h>" will fail. See
+   https://bugs.chromium.org/p/boringssl/issues/detail?id=421
+*/
 #include <openssl/cms.h>
+#include <openssl/pkcs12.h>
 #include <openssl/x509.h>
+#endif
 
 /***************************************************************************/
 


### PR DESCRIPTION
BoringSSL does not provide cms.h but this is an optional dependency for
minizip, conditional on defined(MZ_ZIP_SIGNING).

For the functions called by mz_crypt_init:
- The OpenSSL_add_all_algorithms function is declared in evp.h.
  OpenSSL's hmac.h includes evp.h but BoringSSL's hmac.h does not.
- The ERR_* functions are declared in err.h in both.
- The ENGINE_* functions are declared in engine.h in OpenSSL but are in
  crypto.h for BoringSSL.