### PR TITLE
pc: use absolute lib directory

### DIFF
--- a/minizip.pc.cmakein
+++ b/minizip.pc.cmakein
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@INSTALL_LIB_DIR@
-sharedlibdir=@INSTALL_LIB_DIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+sharedlibdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@INSTALL_INC_DIR@
 
 Name: @PROJECT_NAME@


### PR DESCRIPTION
`INSTALL_LIB_DIR` is set to `CMAKE_INSTALL_LIB_DIR`, and while `CMAKE_INSTALL_PREFIX`
is prepended during install [1], this is not the case for the pkg-config
file. Thus, use the full absolute path `CMAKE_INSTALL_FULL_LIBDIR` for generating
the pkg-config file lib directory variables.

I originally saw this issue while building a package `vfrnav` which indirectly depended on minizip, where `libtool` complained that `lib64` did not exist because `-Llib64` was being passed to the linker, which was coming from minizip's pkg-config file [2].

[1] https://gitlab.kitware.com/cmake/cmake/-/issues/20250
[2] https://src.fedoraproject.org/rpms/libpqxx/pull-request/7