### PR TITLE
Replace use of GNU C definitions with standard definitions in mz.h

### DIFF
--- a/mz.h
+++ b/mz.h
@@ -168,28 +168,28 @@
 #  endif
 #endif
 
-#ifndef __INT8_TYPE__
+#ifndef INT8_MAX
 typedef signed char        int8_t;
 #endif
-#ifndef __INT16_TYPE__
+#ifndef INT16_MAX
 typedef short              int16_t;
 #endif
-#ifndef __INT32_TYPE__
+#ifndef INT32_MAX
 typedef int                int32_t;
 #endif
-#ifndef __INT64_TYPE__
+#ifndef INT64_MAX
 typedef long long          int64_t;
 #endif
-#ifndef __UINT8_TYPE__
+#ifndef UINT8_MAX
 typedef unsigned char      uint8_t;
 #endif
-#ifndef __UINT16_TYPE__
+#ifndef UINT16_MAX
 typedef unsigned short     uint16_t;
 #endif
-#ifndef __UINT32_TYPE__
+#ifndef UINT32_MAX
 typedef unsigned int       uint32_t;
 #endif
-#ifndef __UINT64_TYPE__
+#ifndef UINT64_MAX
 typedef unsigned long long uint64_t;
 #endif
 


### PR DESCRIPTION
With this change minizip-ng can be built successfully on an alternative compiler for embedded systems. As the compiler doesn't define \_\_INT8_TYPE__ etc. it was redefining int8_t etc.