### PR TITLE
minizip.pc: Ensure variables point to an absolute path.

### DIFF
--- a/minizip.pc.cmakein
+++ b/minizip.pc.cmakein
@@ -2,7 +2,7 @@ prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 sharedlibdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@INSTALL_INC_DIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: Minizip zip file manipulation library


### PR DESCRIPTION
With commit 503bfd5c179b the CMake `_IMPORT_PREFIX` has been changed to relative paths.  This breaks the paths reflected by the auto-generated pkgconfig file, as pkgconfig expects those paths to be absolute.

***

Closes #584.