### PR TITLE
Fix SOVERSION in Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ enable_language(C)
 set(VERSION "3.0.2")
 
 # API version
-set(SOVERSION "3.0")
+set(SOVERSION "3")
 
 include(CheckLibraryExists)
 include(CheckSymbolExists)


### PR DESCRIPTION
In Linux (and BSD) the `SOVERSION` only consists of the major version number. The correct symbolic links have to be

```
libminizip.so -> libminizip.so.3
libminizip.so.3 -> libminizip.so.3.0.2
libminizip.so.3.0.2
```

and the SONAME of libminizip.so.3.0.2 is `libminizip.so.3`. By this change the symbolic links are created correctly.

On other platforms, such as Windows and macOS, the `SOVERSION` may well consist of `<major-minor>`. That's why I added the if-else statement.

See also: https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html