### PR TITLE
Fix buffer overrun in mz_path_combine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,31 +11,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu 16 GCC 4.8
-            os: ubuntu-16.04
+          - name: Ubuntu 18 GCC 4.8
+            os: ubuntu-18.04
             compiler: gcc
             cmake-args: -DMZ_CODE_COVERAGE=ON
             version: "4.8"
-            codecov: ubuntu_16_gcc_48
+            codecov: ubuntu_18_gcc_48
 
-          - name: Ubuntu 16 GCC
-            os: ubuntu-16.04
+          - name: Ubuntu 18 GCC
+            os: ubuntu-18.04
             compiler: gcc
             cmake-args: -DMZ_CODE_COVERAGE=ON
-            codecov: ubuntu_16_gcc
+            codecov: ubuntu_18_gcc
 
-          - name: Ubuntu 16 Clang 3.5
-            os: ubuntu-16.04
+          - name: Ubuntu 18 Clang 3.9
+            os: ubuntu-18.04
             compiler: clang
             cmake-args: -DMZ_CODE_COVERAGE=ON
-            codecov: ubuntu_16_clang_35
-            version: "3.5"
-            packages: llvm-3.5
-            gcov-exec: llvm-cov-3.5 gcov
+            codecov: ubuntu_18_clang_39
+            version: "3.7"
+            packages: llvm-3.9
+            gcov-exec: llvm-cov-3.9 gcov
 
           # No code coverage on release builds
-          - name: Ubuntu 16 Clang
-            os: ubuntu-16.04
+          - name: Ubuntu 18 Clang
+            os: ubuntu-18.04
             compiler: clang
             deploy: true
             deploy-name: linux
@@ -162,17 +162,18 @@ jobs:
           - name: macOS Xcode 9.4.1
             os: macOS-latest
             version: "9.4.1"
+            cmake-args: -DMZ_BUILD_UNIT_TESTS=OFF
             deploy: true
             deploy-name: macos
 
           - name: macOS Xcode
             os: macOS-latest
-            cmake-args: -DMZ_CODE_COVERAGE=ON
+            cmake-args: -DMZ_CODE_COVERAGE=ON -DMZ_SIGNING=OFF
             codecov: macos_xcode
 
           - name: macOS Xcode LibCompression
             os: macOS-latest
-            cmake-args: -DMZ_CODE_COVERAGE=ON -DMZ_LIBCOMP=ON
+            cmake-args: -DMZ_CODE_COVERAGE=ON -DMZ_LIBCOMP=ON -DMZ_SIGNING=OFF
             codecov: macos_xcode_libcompression
 
           - name: macOS Xcode OpenSSL

--- a/mz_os.c
+++ b/mz_os.c
@@ -33,7 +33,9 @@ int32_t mz_path_combine(char *path, const char *join, int32_t max_path) {
         path[max_path - 1] = 0;
     } else {
         mz_path_append_slash(path, max_path, MZ_PATH_SLASH_PLATFORM);
-        strncat(path, join, max_path - path_len);
+        path_len = (int32_t)strlen(path);
+        if (max_path > path_len)
+            strncat(path, join, max_path - path_len - 1);
     }
 
     return MZ_OK;


### PR DESCRIPTION
The path may be overrun by two bytes. One because mz_path_append_slash
may append to path without updating path_len, and another one because
strncat always appends a NUL byte after writing N bytes.

Rescan the path length and subtract one from the strncat length parameter
to make sure we stay within max_path.