### PR TITLE
CMakeLists.txt: fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,7 +661,7 @@ endif()
 list(APPEND MINIZIP_INC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Create minizip library
-project(minizip${MZ_PROJECT_SUFFIX} VERSION ${VERSION})
+project(minizip${MZ_PROJECT_SUFFIX} LANGUAGES C VERSION ${VERSION})
 
 if(NOT ${MZ_PROJECT_SUFFIX} STREQUAL "")
     message(STATUS "Project configured as ${PROJECT_NAME}")


### PR DESCRIPTION
Fix the following build failure without a working C++ compiler raised since version 2.0.0 and https://github.com/zlib-ng/minizip-ng/commit/d383a5f2fca127d24407ff26adce579d63b85310:

```
CMake Error at /nvmedata/autobuild/instance-20/output-1/host/share/cmake-3.18/Modules/CMakeTestCXXCompiler.cmake:59 (message):
  The C++ compiler

    "/usr/bin/c++"

  is not able to compile a simple test program.
```

Fixes:
 - http://autobuild.buildroot.org/results/4452bc35b41414a5e8a0e9831b0854228df5fba4

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>