### PR TITLE
Fix mz_os_get_file_date on POSIX

### DIFF
--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -222,8 +222,7 @@ int32_t mz_os_get_file_date(const char *path, time_t *modified_date, time_t *acc
         /* Not all systems allow stat'ing a file with / appended */
         len = strlen(path);
         name = (char *)malloc(len + 1);
-        strncpy(name, path, len);
-        name[len - 1] = 0;
+        strncpy(name, path, len + 1);
         mz_path_remove_slash(name);
 
         if (stat(name, &path_stat) == 0) {

--- a/test/test.c
+++ b/test/test.c
@@ -1257,6 +1257,17 @@ int32_t test_unzip_compat64(void)
 }
 #endif
 
+int32_t test_get_file_date(const char *path)
+{
+    int32_t err = mz_os_get_file_date(path, NULL, NULL, NULL);
+    if (err != MZ_OK) {
+        printf("get file date %s returned %" PRId32 "\n", path, err);
+        return err;
+    }
+    printf("get file date.. Ok\n");
+    return err;
+}
+
 /***************************************************************************/
 
 int main(int argc, const char *argv[])
@@ -1298,6 +1309,7 @@ int main(int argc, const char *argv[])
     err |= test_crypt_aes();
     err |= test_crypt_hmac();
 #endif
+    err |= test_get_file_date(argv[0]);
 
     return err;
 }

--- a/test/test.c
+++ b/test/test.c
@@ -1261,10 +1261,10 @@ int32_t test_get_file_date(const char *path)
 {
     int32_t err = mz_os_get_file_date(path, NULL, NULL, NULL);
     if (err != MZ_OK) {
-        printf("get file date %s returned %" PRId32 "\n", path, err);
+        printf("Get file date %s returned %" PRId32 "\n", path, err);
         return err;
     }
-    printf("get file date.. Ok\n");
+    printf("Get file date.. OK\n");
     return err;
 }
 


### PR DESCRIPTION
mz_os_get_file_date (on a file, or on a directory without a trailing slash) was broken by commit fe36527157ff96226f5309a99c806475ee0b75d2 , which always truncates the filename before passing it to `stat`.

Revert commit fe36527157ff96226f5309a99c806475ee0b75d2 and add a simple test for mz_os_get_file_date.