### PR TITLE
Fixed writing backslashes in zip on Windows.

### DIFF
--- a/mz_os.h
+++ b/mz_os.h
@@ -41,8 +41,9 @@ extern "C" {
                                          (MZ_VERSION_MADEBY_ZIP_VERSION))
 
 #define MZ_PATH_SLASH_UNIX              ('/')
+#define MZ_PATH_SLASH_WINDOWS           ('\\')
 #if defined(_WIN32)
-#  define MZ_PATH_SLASH_PLATFORM        ('\\')
+#  define MZ_PATH_SLASH_PLATFORM        (MZ_PATH_SLASH_WINDOWS)
 #else
 #  define MZ_PATH_SLASH_PLATFORM        (MZ_PATH_SLASH_UNIX)
 #endif


### PR DESCRIPTION
All slashes should be written as forward slashes according
to the zip app note section 4.4.17.1.

Co-authored-by: jeremybernstein@users.noreply.github.com