### PR TITLE
Switch getrandom() and arc4random_buf() usage order

### DIFF
--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -117,7 +117,22 @@ void mz_os_utf8_string_delete(uint8_t **string) {
 
 /***************************************************************************/
 
-#if defined(HAVE_ARC4RANDOM_BUF)
+#if defined(HAVE_GETRANDOM)
+int32_t mz_os_rand(uint8_t *buf, int32_t size) {
+    int32_t left = size;
+    int32_t written = 0;
+
+    while (left > 0) {
+        written = getrandom(buf, left, 0);
+        if (written < 0)
+            return MZ_INTERNAL_ERROR;
+
+        buf += written;
+        left -= written;
+    }
+    return size - left;
+}
+#elif defined(HAVE_ARC4RANDOM_BUF)
 int32_t mz_os_rand(uint8_t *buf, int32_t size) {
     if (size < 0)
         return 0;
@@ -136,21 +151,6 @@ int32_t mz_os_rand(uint8_t *buf, int32_t size) {
     }
     for (; left > 0; left--, buf++) {
         *buf = arc4random() & 0xFF;
-    }
-    return size - left;
-}
-#elif defined(HAVE_GETRANDOM)
-int32_t mz_os_rand(uint8_t *buf, int32_t size) {
-    int32_t left = size;
-    int32_t written = 0;
-
-    while (left > 0) {
-        written = getrandom(buf, left, 0);
-        if (written < 0)
-            return MZ_INTERNAL_ERROR;
-
-        buf += written;
-        left -= written;
     }
     return size - left;
 }


### PR DESCRIPTION
We need to match the order of inclusions at the top of the file otherwise we might end up trying to use arc4random_buf() when available (because HAVE_ARC4RANODM_BUF is set) even though we hit HAVE_GETRANDOM first above and only included <sys/random.h> because of it.

Besides, if getrandom() is available, we should really prefer it anyway.

Fixes an implicit function declaration:
```
minizip-ng-3.0.6/mz_os_posix.c:124:5: error: implicit declaration of function 'arc4random_buf' [-Werror=implicit-function-declaration]
```

Signed-off-by: Sam James <sam@gentoo.org>