### PR TITLE
zlib-minizip compability fixes: CRC error on half-read files and unzOpenCurrentFile without close

### DIFF
--- a/mz_compat.c
+++ b/mz_compat.c
@@ -875,6 +875,11 @@ int unzOpenCurrentFile3(unzFile file, int *method, int *level, int raw, const ch
     if (level != NULL)
         *level = 0;
 
+    if (mz_zip_entry_is_open(compat->handle) == MZ_OK) {
+        /* zlib minizip does not error out here if close returns errors */
+        unzCloseCurrentFile(file);
+    }
+
     compat->total_out = 0;
     err = mz_zip_entry_read_open(compat->handle, (uint8_t)raw, password);
     if (err == MZ_OK)

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -2105,7 +2105,7 @@ int32_t mz_zip_entry_read_close(void *handle, uint32_t *crc32, int64_t *compress
     }
 
     /* If entire entry was not read verification will fail */
-    if ((err == MZ_OK) && (total_in > 0) && (!zip->entry_raw)) {
+    if ((err == MZ_OK) && (total_in == zip->file_info.compressed_size) && (!zip->entry_raw)) {
 #ifdef HAVE_WZAES
         /* AES zip version AE-1 will expect a valid crc as well */
         if (zip->file_info.aes_version <= 0x0001)


### PR DESCRIPTION
I found a few incompatibilities with the minizip from zlib while changing from an old zlib to zlib-ng + minizip-ng. These fixes are just suggestion as I don't really know anything about this code base, but working code is better than trying to explain what I mean.

I forgot to call unzCloseCurrentFile between calls to unzOpenCurrentFile. It didn't fail until it came across an uncompressed entry, then it tried to read approximately -800kiB through the IO-wrapper :). Forgetting to close the file is probably an user error but it looks like zlib handles that (on purpose) and will close any currently open entry in the open function. This commit replicates that behavior from zlib-minizip.

zlib code:
https://github.com/madler/zlib/blob/master/contrib/minizip/unzip.c#L1494


Calling unzCloseCurrentFile on a file that isn't completely read will return MZ_CRC_ERROR/UNZ_CRCERROR even if there isn't anything wrong with the file. The comment in the code suggests that this is a known issue ("If entire entry was not read verification will fail"). Zlib minizip will only check the crc if the whole file was read. This commit seems to work for zlib and storage streams, but I don't really know if it's right, but feels analogous to the zlib variant.

zlib code:
https://github.com/madler/zlib/blob/master/contrib/minizip/unzip.c#L2024

Best regards
Markus Ålind