### PR TITLE
Search system for GTest before downloading. #654

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 include(FetchContent)
 
+find_package(GTest)
+
 enable_language(CXX)
 
 if(NOT TARGET GTest::GTest)


### PR DESCRIPTION
Distributions often do builds with no network access available for both security reasons and also to ensure reproducibility.

This change tells CMake to query the system for a copy of gtest, but if it's not available, it'll fall back to downloading via FetchContent.