### PR TITLE
CMake: fix ALIAS target name to be consistent with imported target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,6 +685,7 @@ set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
     CACHE PATH "Installation directory for pkgconfig (.pc) files")
 
 add_library(${PROJECT_NAME} ${MINIZIP_SRC} ${MINIZIP_HDR})
+add_library(MINIZIP::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
                       VERSION ${VERSION}
@@ -716,9 +717,6 @@ if(MZ_COMPAT)
     target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 endif()
-
-# Create minizip alias
-add_library(MINIZIP::minizip ALIAS ${PROJECT_NAME})
 
 # Install files
 if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)


### PR DESCRIPTION
Revert https://github.com/zlib-ng/minizip-ng/commit/9e9d8203e57f51542a1e46ee1ea2903029c88229, it's not consistent with imported target, which is `MINIZIP::minizip` if MZ_COMPAT is ON else `MINIZIP::minizip-ng`.

I don't know if you want to set ALIAS target AND imported target as `MINIZIP::minizip` unconditionally (`MINIZIP::minizip-ng` is probably a better choice), but if that's the case, you should use `EXPORT_NAME` property (indeed as per current CMakeLists, logical target name depends on PROJECT_NAME which depends on MZ_COMPAT, and by default export target name is logical target name) and also avoid to give a conditional name to CMake config file.