### PR TITLE
Create parent directory before extracting symlink

### DIFF
--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -719,7 +719,8 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
     }
 
     /* If symbolic link then properly construct destination path and link path */
-    if (mz_zip_entry_is_symlink(reader->zip_handle) == MZ_OK) {
+    if ((mz_zip_entry_is_symlink(reader->zip_handle) == MZ_OK) &&
+        (mz_path_has_slash(pathwfs) == MZ_OK)) {
         mz_path_remove_slash(pathwfs);
         mz_path_remove_filename(directory);
     }


### PR DESCRIPTION
At least when using Info-ZIP 3.0, symlinks to both files and directories lack a trailing slash, so the second mz_path_remove_filename is unnecessary (and could break things if the parent directory doesn't precede the symlink in the file). If other implementations do add a trailing slash, the if statement should handle that.