### PR TITLE
Fixed incorrect handling of long odd length passwords

### DIFF
--- a/mz_crypt_win32.c
+++ b/mz_crypt_win32.c
@@ -561,8 +561,8 @@ int32_t mz_crypt_hmac_init(void *handle, const void *key, int32_t key_length) {
         hmac->error = GetLastError();
         err = MZ_CRYPT_ERROR;
     } else {
-        /* Zero-pad odd key lengths */
-        if (pad_key_length % 2 == 1)
+        /* Pad single char key to work around CryptImportKey returning ERROR_INVALID_PARAMETER */
+        if (pad_key_length == 1)
             pad_key_length += 1;
         key_blob_size = sizeof(key_blob_header_s) + pad_key_length;
         key_blob = (uint8_t *)malloc(key_blob_size);


### PR DESCRIPTION
Hei,

Here is the PR done on top of the `develop` branch instead of `master`.

For reference, my understanding of the issue is as follows:
- `CryptImportKey` fails with a play key of length 1 and returns `ERROR_INVALID_PARAMETER`, as previously raised here https://developercommunity.visualstudio.com/t/cryptimportkey-fails-to-import-plaintext-key-with/1215483. The link does not have the files mentioned, but I can reproduce that issue in a test program. 
- The original fix for that issue added a padding when the key length is odd.
- One issue with the original fix is that it assumed that key string is zero terminated and read past the provided length. That was already fixed in `c6c4f2cb2bcd28e220cee70cb3d4b0931e2f5ab4` and it's not yet in `master`.
- But padding when the key length is odd leads to incorrect results when passwords are odd and long. That's because for longer keys a hash is calculated which is different when the extra zero is included.

So this commit on top of previous fixes:
- only pads with an extra zero for a key length of 1 (which is what is needed to work around the `CryptImportKey`)
- has a test for HMAC SHA1 with the key `"h"` and message `"helloworld"` (like the issue reported to Microsoft). This test is written to also cover the fix against the assumption that key is zero terminated.
- has two tests for `mz_crypt_pbkdf2` which is how I discovered the problem with long odd lengths keys/passwords.
I also tested that if I remove the fixes the tests fail.