### PR TITLE
Add test for CLOCK_MONOTONIC support

### DIFF
--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -343,8 +343,15 @@ uint64_t mz_os_ms_time(void) {
 
     ts.tv_sec = mts.tv_sec;
     ts.tv_nsec = mts.tv_nsec;
-#else
+#elif !defined(_POSIX_MONOTONIC_CLOCK) || _POSIX_MONOTONIC_CLOCK < 0
+    clock_gettime(CLOCK_REALTIME, &ts);
+#elif _POSIX_MONOTONIC_CLOCK > 0
     clock_gettime(CLOCK_MONOTONIC, &ts);
+#else
+    if (sysconf(_SC_MONOTONIC_CLOCK) > 0)
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+    else
+        clock_gettime(CLOCK_REALTIME, &ts);
 #endif
 
     return ((uint64_t)ts.tv_sec * 1000) + ((uint64_t)ts.tv_nsec / 1000000);


### PR DESCRIPTION
Instead of always using CLOCK_MONOTONIC, use POSIX feature testing to determine support at compile-time, or if necessary at run-time using sysconf. If not supported, falls back to CLOCK_REALTIME.