### PR TITLE
Fix MZ_FETCH_LIBS option for non-WIN32 systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(MZ_BZIP2 "Enables BZIP2 compression" ON)
 option(MZ_LZMA "Enables LZMA & XZ compression" ON)
 option(MZ_ZSTD "Enables ZSTD compression" ON)
 cmake_dependent_option(MZ_LIBCOMP "Enables Apple compression" ON "APPLE" OFF)
-cmake_dependent_option(MZ_FETCH_LIBS "Enables fetching third-party libraries if not found" ON "WIN32" OFF)
+option(MZ_FETCH_LIBS "Enables fetching third-party libraries if not found" ${WIN32})
 option(MZ_FORCE_FETCH_LIBS "Enables fetching third-party libraries always" OFF)
 # Encryption support options
 option(MZ_PKCRYPT "Enables PKWARE traditional encryption" ON)


### PR DESCRIPTION
Using `cmake_dependent_option` overrides a previously set directory scope MZ_FETCH_LIBS variable. This means if a project sets MZ_FETCH_LIBS before adding minizip-ng as a subdirectory in order to force it to fetch zlib, it will set the variable to OFF, only use `find_library` and never fetch zlib on non-WIN32 systems. This is a regression from previous behaviour.

Instead, revert back to using `option` as this obeys a directory scope MZ_FETCH_LIBS variable set by a parent directory, allowing said parent directory to control zlib version.
