### PR TITLE
Fix cmake install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -702,7 +702,7 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     install(EXPORT ${MINIZIP_TARGET}
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${MINIZIP_TARGET}"
             NAMESPACE "MINIZIP::")
 
     # Create and install CMake package config version file to allow find_package()
@@ -723,11 +723,11 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
     configure_package_config_file(
         ${CMAKE_CURRENT_BINARY_DIR}/minizip-config.cmake.in
         ${MINIZIP_TARGET}-config.cmake
-        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake")
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${MINIZIP_TARGET}")
 
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${MINIZIP_TARGET}-config-version.cmake
                   ${CMAKE_CURRENT_BINARY_DIR}/${MINIZIP_TARGET}-config.cmake
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake")
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${MINIZIP_TARGET}")
 endif()
 if(NOT SKIP_INSTALL_HDR AND NOT SKIP_INSTALL_ALL)
     install(FILES ${MINIZIP_HDR} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${MINIZIP_TARGET}")


### PR DESCRIPTION
CMake's `find_package()` will search [these paths](https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure) when attempting to find a package config (note that while CMake's docs appear to indicate that `<name>` is optional (`*`) it's actually required):
```
<prefix>/
<prefix>/(cmake|CMake)/
<prefix>/<name>*/
<prefix>/<name>*/(cmake|CMake)/
<prefix>/<name>*/(cmake|CMake)/<name>*/
<prefix>/(lib/<arch>|lib*|share)/cmake/<name>*/
<prefix>/(lib/<arch>|lib*|share)/<name>*/
<prefix>/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/
<prefix>/<name>*/(lib/<arch>|lib*|share)/cmake/<name>*/
<prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/
<prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/
```

The current minizip-ng config install location of `<prefix>/lib*/cmake/minizip-config.cmake` will not be found because the config is expected to be in a `minizip` subdirectory under `cmake`.

This can be tested with:
```
set(CMAKE_PREFIX_PATH "/tmp/a1f568d6/install;/tmp/95d43940/install")

find_package(minizip CONFIG REQUIRED)

message("${minizip_DIR}")
```