### PR TITLE
mz_os_posix.c - fix warning caused by missing cast of return value of strdup

### DIFF
--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -90,7 +90,7 @@ uint8_t *mz_os_utf8_string_create(const char *string, int32_t encoding) {
 }
 #else
 uint8_t *mz_os_utf8_string_create(const char *string, int32_t encoding) {
-    return strdup(string);
+    return (uint8_t*)strdup(string);
 }
 #endif
 


### PR DESCRIPTION
I have run into https://github.com/zlib-ng/minizip-ng/issues/705, too.
Here is a fix.