### PR TITLE
CMake: Fix build with OpenBSD #711

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,7 +455,7 @@ if(WIN32)
     set(MZ_LIBBSD OFF)
     set(MZ_ICONV OFF)
 else()
-    list(APPEND STDLIB_DEF -D_POSIX_C_SOURCE=200809L)
+    list(APPEND STDLIB_DEF -D_POSIX_C_SOURCE=200809L -D_BSD_SOURCE)
     list(APPEND MINIZIP_SRC mz_os_posix.c mz_strm_os_posix.c)
 
     if(MZ_PKCRYPT OR MZ_WZAES)


### PR DESCRIPTION
Setting _POSIX_C_SOURCE on OpenBSD breaks the build. _BSD_SOURCE needs to be set at the same time to enable some functions.

```
In file included from /home/brad/tmp/ffmpeg-ports/ports/pobj/minizip-4.0.0/minizip-ng-4.0.0/test/test_main.cc:5:
In file included from /usr/local/include/gtest/gtest.h:55:
In file included from /usr/include/c++/v1/ostream:140:
In file included from /usr/include/c++/v1/locale:218:
/usr/include/c++/v1/__bsd_locale_fallbacks.h:122:17: error: use of undeclared identifier 'vasprintf'; did you mean 'vsprintf'?
    int __res = vasprintf(__s, __format, __va);
                ^
/usr/include/c++/v1/cstdio:124:9: note: 'vsprintf' declared here
using ::vsprintf _LIBCPP_USING_IF_EXISTS;
        ^
In file included from /home/brad/tmp/ffmpeg-ports/ports/pobj/minizip-4.0.0/minizip-ng-4.0.0/test/test_main.cc:5:
In file included from /usr/local/include/gtest/gtest.h:55:
In file included from /usr/include/c++/v1/ostream:140:
In file included from /usr/include/c++/v1/locale:218:
/usr/include/c++/v1/__bsd_locale_fallbacks.h:122:27: error: cannot initialize a parameter of type 'char *' with an lvalue of type 'char **'
    int __res = vasprintf(__s, __format, __va);
                          ^~~
/usr/include/stdio.h:269:21: note: passing argument to parameter here
int      vsprintf(char *, const char *, __va_list);
                        ^
2 errors generated.
```