### PR TITLE
Only return MZ_MEM_ERROR if no other error code was received before.

### DIFF
--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1802,7 +1802,7 @@ static int32_t mz_zip_entry_open_int(void *handle, uint8_t raw, int16_t compress
             err = MZ_PARAM_ERROR;
     }
 
-    if (!zip->compress_stream)
+    if (err == MZ_OK && !zip->compress_stream)
         err = MZ_MEM_ERROR;
 
     if (err == MZ_OK) {


### PR DESCRIPTION
For example, opening an encrypted file with incorrect password should return MZ_PASSWORD_ERROR (as did 3.x).
The additional "err == MZ_OK" check makes sure that the correct error code is returned.