### PR TITLE
Fix for memory leak 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,19 @@ jobs:
             cmake-args: -D MZ_WITH_SANITIZER=Address
             codecov: ubuntu_gcc
 
+          - name: Ubuntu GCC UBSAN
+            os: ubuntu-latest
+            compiler: gcc
+            cxx-compiler: g++
+            cmake-args: -D MZ_WITH_SANITIZER=Undefined
+            codecov: ubuntu_gcc
+
+          - name: Ubuntu GCC MSAN
+            os: ubuntu-latest
+            compiler: gcc
+            cxx-compiler: g++
+            cmake-args: -D MZ_WITH_SANITIZER=Memory
+            codecov: ubuntu_gcc
 
           # No code coverage on release builds
           - name: Ubuntu 20 Clang

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,14 @@ jobs:
             compiler: gcc
             cxx-compiler: g++
 
+          - name: Ubuntu GCC ASAN
+            os: ubuntu-latest
+            compiler: gcc
+            cxx-compiler: g++
+            cmake-args: -D MZ_WITH_SANITIZER=Address
+            codecov: ubuntu_gcc
+
+
           # No code coverage on release builds
           - name: Ubuntu 20 Clang
             os: ubuntu-20.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ include(CheckTypeSize)
 include(GNUInstallDirs)
 include(FeatureSummary)
 
+include(cmake/detect-sanitizer.cmake)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
@@ -59,6 +61,10 @@ option(MZ_BUILD_TESTS "Builds minizip test executable" OFF)
 option(MZ_BUILD_UNIT_TESTS "Builds minizip unit test project" OFF)
 option(MZ_BUILD_FUZZ_TESTS "Builds minizip fuzzer executables" OFF)
 option(MZ_CODE_COVERAGE "Builds with code coverage flags" OFF)
+
+# Add multi-choice option
+set(MZ_WITH_SANITIZER AUTO CACHE STRING "Enable sanitizer support")
+set_property(CACHE MZ_WITH_SANITIZER PROPERTY STRINGS "Memory" "Address" "Undefined" "Thread")
 
 # Backwards compatibility
 if(DEFINED MZ_BUILD_TEST)
@@ -620,6 +626,16 @@ if(MZ_COMPAT)
     endif()
     list(APPEND MINIZIP_SRC mz_compat.c)
     list(APPEND MINIZIP_HDR mz_compat.h ${CMAKE_CURRENT_BINARY_DIR}/zip.h ${CMAKE_CURRENT_BINARY_DIR}/unzip.h)
+endif()
+
+if(MZ_WITH_SANITIZER STREQUAL "Address")
+    add_address_sanitizer()
+elseif(MZ_WITH_SANITIZER STREQUAL "Memory")
+    add_memory_sanitizer()
+elseif(MZ_WITH_SANITIZER STREQUAL "Thread")
+    add_thread_sanitizer()
+elseif(MZ_WITH_SANITIZER STREQUAL "Undefined")
+    add_undefined_sanitizer()
 endif()
 
 # Set compiler options

--- a/cmake/detect-sanitizer.cmake
+++ b/cmake/detect-sanitizer.cmake
@@ -1,0 +1,166 @@
+# detect-sanitizer.cmake -- Detect supported compiler sanitizer flags
+# Licensed under the Zlib license, see LICENSE.md for details
+
+macro(add_common_sanitizer_flags)
+    if(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+        add_compile_options(-g3)
+    endif()
+    # check_c_compiler_flag(-fno-omit-frame-pointer HAVE_NO_OMIT_FRAME_POINTER)
+    # if(HAVE_NO_OMIT_FRAME_POINTER)
+        add_compile_options(-fno-omit-frame-pointer)
+        add_link_options(-fno-omit-frame-pointer)
+    # endif()
+    # check_c_compiler_flag(-fno-optimize-sibling-calls HAVE_NO_OPTIMIZE_SIBLING_CALLS)
+    # if(HAVE_NO_OPTIMIZE_SIBLING_CALLS)
+        add_compile_options(-fno-optimize-sibling-calls)
+        add_link_options(-fno-optimize-sibling-calls)
+    # endif()
+endmacro()
+
+macro(check_sanitizer_support known_checks supported_checks)
+    set(available_checks "")
+
+    # Build list of supported sanitizer flags by incrementally trying compilation with
+    # known sanitizer checks
+
+    foreach(check ${known_checks})
+        if(available_checks STREQUAL "")
+            set(compile_checks "${check}")
+        else()
+            set(compile_checks "${available_checks},${check}")
+        endif()
+
+        set(CMAKE_REQUIRED_FLAGS -fsanitize=${compile_checks})
+
+        check_c_source_compiles("int main() { return 0; }" HAVE_SANITIZER_${check}
+            FAIL_REGEX "not supported|unrecognized command|unknown option")
+
+        set(CMAKE_REQUIRED_FLAGS)
+
+        if(HAVE_SANITIZER_${check})
+            set(available_checks ${compile_checks})
+        endif()
+    endforeach()
+
+    set(${supported_checks} ${available_checks})
+endmacro()
+
+macro(add_address_sanitizer)
+    set(known_checks
+        address
+        pointer-compare
+        pointer-subtract
+        )
+
+    check_sanitizer_support("${known_checks}" supported_checks)
+    if(NOT ${supported_checks} STREQUAL "")
+        message(STATUS "Address sanitizer is enabled: ${supported_checks}")
+        add_compile_options(-fsanitize=${supported_checks})
+        add_link_options(-fsanitize=${supported_checks})
+        add_common_sanitizer_flags()
+    else()
+        message(STATUS "Address sanitizer is not supported")
+    endif()
+
+    if(CMAKE_CROSSCOMPILING_EMULATOR)
+        # Only check for leak sanitizer if not cross-compiling due to qemu crash
+        message(WARNING "Leak sanitizer is not supported when cross compiling")
+    else()
+        # Leak sanitizer requires address sanitizer
+        check_sanitizer_support("leak" supported_checks)
+        if(NOT ${supported_checks} STREQUAL "")
+            message(STATUS "Leak sanitizer is enabled: ${supported_checks}")
+            add_compile_options(-fsanitize=${supported_checks})
+            add_link_options(-fsanitize=${supported_checks})
+            add_common_sanitizer_flags()
+        else()
+            message(STATUS "Leak sanitizer is not supported")
+        endif()
+    endif()
+endmacro()
+
+macro(add_memory_sanitizer)
+    check_sanitizer_support("memory" supported_checks)
+    if(NOT ${supported_checks} STREQUAL "")
+        message(STATUS "Memory sanitizer is enabled: ${supported_checks}")
+        add_compile_options(-fsanitize=${supported_checks})
+        add_link_options(-fsanitize=${supported_checks})
+        add_common_sanitizer_flags()
+
+        check_c_compiler_flag(-fsanitize-memory-track-origins HAVE_MEMORY_TRACK_ORIGINS)
+        if(HAVE_MEMORY_TRACK_ORIGINS)
+            add_compile_options(-fsanitize-memory-track-origins)
+            add_link_options(-fsanitize-memory-track-origins)
+        endif()
+    else()
+        message(STATUS "Memory sanitizer is not supported")
+    endif()
+endmacro()
+
+macro(add_thread_sanitizer)
+    check_sanitizer_support("thread" supported_checks)
+    if(NOT ${supported_checks} STREQUAL "")
+        message(STATUS "Thread sanitizer is enabled: ${supported_checks}")
+        add_compile_options(-fsanitize=${supported_checks})
+        add_link_options(-fsanitize=${supported_checks})
+        add_common_sanitizer_flags()
+    else()
+        message(STATUS "Thread sanitizer is not supported")
+    endif()
+endmacro()
+
+macro(add_undefined_sanitizer)
+    set(known_checks
+        array-bounds
+        bool
+        bounds
+        builtin
+        enum
+        float-cast-overflow
+        float-divide-by-zero
+        function
+        integer-divide-by-zero
+        local-bounds
+        null
+        nonnull-attribute
+        pointer-overflow
+        return
+        returns-nonnull-attribute
+        shift
+        shift-base
+        shift-exponent
+        signed-integer-overflow
+        undefined
+        unsigned-integer-overflow
+        unsigned-shift-base
+        vla-bound
+        vptr
+        )
+
+    # Only check for alignment sanitizer flag if unaligned access is not supported
+    if(NOT WITH_UNALIGNED)
+        list(APPEND known_checks alignment)
+    endif()
+    # Object size sanitizer has no effect at -O0 and produces compiler warning if enabled
+    if(NOT CMAKE_C_FLAGS MATCHES "-O0")
+        list(APPEND known_checks object-size)
+    endif()
+
+    check_sanitizer_support("${known_checks}" supported_checks)
+
+    if(NOT ${supported_checks} STREQUAL "")
+        message(STATUS "Undefined behavior sanitizer is enabled: ${supported_checks}")
+        add_compile_options(-fsanitize=${supported_checks})
+        add_link_options(-fsanitize=${supported_checks})
+
+        # Group sanitizer flag -fsanitize=undefined will automatically add alignment, even if
+        # it is not in our sanitize flag list, so we need to explicitly disable alignment sanitizing.
+        if(WITH_UNALIGNED)
+            add_compile_options(-fno-sanitize=alignment)
+        endif()
+
+        add_common_sanitizer_flags()
+    else()
+        message(STATUS "Undefined behavior sanitizer is not supported")
+    endif()
+endmacro()

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -1737,6 +1737,8 @@ int32_t mz_zip_writer_copy_from_reader(void *handle, void *reader) {
 
         err = mz_zip_writer_entry_open(writer, file_info);
 
+        mz_crypt_sha_delete(&writer->hash);
+
         if ((err == MZ_OK) &&
             (mz_zip_attrib_is_dir(writer->file_info.external_fa, writer->file_info.version_madeby) != MZ_OK)) {
             err = mz_zip_writer_add(writer, reader_zip_handle, mz_zip_entry_read);

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -23,6 +23,16 @@
 
 /***************************************************************************/
 
+/* for alloca */
+
+#if defined(_WIN32)
+  #include <malloc.h>
+#else
+  #include <alloca.h>
+#endif
+
+/***************************************************************************/
+
 #define MZ_DEFAULT_PROGRESS_INTERVAL    (1000u)
 
 #define MZ_ZIP_CD_FILENAME              ("__cdcd__")
@@ -650,8 +660,15 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
     int32_t err_attrib = 0;
     int32_t err = MZ_OK;
     int32_t err_cb = MZ_OK;
-    char pathwfs[512];
-    char directory[512];
+
+    size_t path_length = strlen(path);
+
+/* If code ever sets C99 as a minimum can use this instead of alloca
+     char pathwfs[path_length + 1];
+     char directory[path_length + 1];
+*/
+    char *pathwfs = (char *)alloca(path_length + 1) ;
+    char *directory = (char *)alloca(path_length + 1) ;
 
     if (mz_zip_reader_is_open(reader) != MZ_OK)
         return MZ_PARAM_ERROR;
@@ -659,15 +676,15 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
         return MZ_PARAM_ERROR;
 
     /* Convert to forward slashes for unix which doesn't like backslashes */
-    strncpy(pathwfs, path, sizeof(pathwfs) - 1);
-    pathwfs[sizeof(pathwfs) - 1] = 0;
+    pathwfs[0] = 0;
+    strncat(pathwfs, path, path_length);
     mz_path_convert_slashes(pathwfs, MZ_PATH_SLASH_UNIX);
 
     if (reader->entry_cb)
         reader->entry_cb(handle, reader->entry_userdata, reader->file_info, pathwfs);
 
-    strncpy(directory, pathwfs, sizeof(directory) - 1);
-    directory[sizeof(directory) - 1] = 0;
+    directory[0] = 0;
+    strncat(directory, pathwfs, path_length);
     mz_path_remove_filename(directory);
 
     /* If it is a directory entry then create a directory instead of writing file */
@@ -809,39 +826,59 @@ int32_t mz_zip_reader_save_all(void *handle, const char *destination_dir) {
     mz_zip_reader *reader = (mz_zip_reader *)handle;
     int32_t err = MZ_OK;
     char *utf8_string = NULL;
-    char path[512];
-    char utf8_name[256];
-    char resolved_name[256];
+    char *path = NULL;
+    char *utf8_name = NULL;
+    char *resolved_name = NULL;
 
     err = mz_zip_reader_goto_first_entry(handle);
 
     if (err == MZ_END_OF_LIST)
         return err;
 
+    /* Assume 4 bytes per character needed + 1 for terminating null */
+    int buff_size = reader->file_info->filename_size * 4 + 1;
+    int resolved_size = buff_size;
+
+    path = (char *)malloc(resolved_size);
+    utf8_name = (char *)malloc(buff_size);
+    resolved_name = (char *)malloc(resolved_size);
+
     while (err == MZ_OK) {
+        /* Assume 4 bytes per character needed + 1 for terminating null */
+        buff_size = reader->file_info->filename_size * 4 + 1;
+        resolved_size = buff_size;
+
+        if(destination_dir)
+            /* +1 is for the "/" separator */
+            resolved_size += (int)strlen(destination_dir) + 1;
+
+        path = (char *)realloc(path, resolved_size);
+        utf8_name = (char *)realloc(utf8_name, buff_size);
+        resolved_name = (char *)realloc(resolved_name, resolved_size);
+
         /* Construct output path */
         path[0] = 0;
 
-        strncpy(utf8_name, reader->file_info->filename, sizeof(utf8_name) - 1);
-        utf8_name[sizeof(utf8_name) - 1] = 0;
+        strncpy(utf8_name, reader->file_info->filename, buff_size - 1);
+        utf8_name[buff_size - 1] = 0;
 
         if ((reader->encoding > 0) && (reader->file_info->flag & MZ_ZIP_FLAG_UTF8) == 0) {
             utf8_string = mz_os_utf8_string_create(reader->file_info->filename, reader->encoding);
             if (utf8_string) {
-                strncpy(utf8_name, utf8_string, sizeof(utf8_name) - 1);
-                utf8_name[sizeof(utf8_name) - 1] = 0;
+                strncpy(utf8_name, (char *)utf8_string, buff_size - 1);
+                utf8_name[buff_size - 1] = 0;
                 mz_os_utf8_string_delete(&utf8_string);
             }
         }
 
-        err = mz_path_resolve(utf8_name, resolved_name, sizeof(resolved_name));
+        err = mz_path_resolve(utf8_name, resolved_name, resolved_size);
         if (err != MZ_OK)
             break;
 
         if (destination_dir)
-            mz_path_combine(path, destination_dir, sizeof(path));
+            mz_path_combine(path, destination_dir, resolved_size);
 
-        mz_path_combine(path, resolved_name, sizeof(path));
+        mz_path_combine(path, resolved_name, resolved_size);
 
         /* Save file to disk */
         err = mz_zip_reader_entry_save_file(handle, path);
@@ -849,6 +886,13 @@ int32_t mz_zip_reader_save_all(void *handle, const char *destination_dir) {
         if (err == MZ_OK)
             err = mz_zip_reader_goto_next_entry(handle);
     }
+
+    if (path)
+        free(path) ;
+    if (utf8_name)
+        free(utf8_name) ;
+    if (resolved_name)
+        free(resolved_name) ;
 
     if (err == MZ_END_OF_LIST)
         return MZ_OK;

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -23,16 +23,6 @@
 
 /***************************************************************************/
 
-/* for alloca */
-
-#if defined(_WIN32)
-  #include <malloc.h>
-#else
-  #include <alloca.h>
-#endif
-
-/***************************************************************************/
-
 #define MZ_DEFAULT_PROGRESS_INTERVAL    (1000u)
 
 #define MZ_ZIP_CD_FILENAME              ("__cdcd__")
@@ -663,12 +653,8 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
 
     size_t path_length = strlen(path);
 
-/* If code ever sets C99 as a minimum can use this instead of alloca
-     char pathwfs[path_length + 1];
-     char directory[path_length + 1];
-*/
-    char *pathwfs = (char *)alloca(path_length + 1) ;
-    char *directory = (char *)alloca(path_length + 1) ;
+    char *pathwfs = (char *)malloc(path_length + 1) ;
+    char *directory = (char *)malloc(path_length + 1) ;
 
     if (mz_zip_reader_is_open(reader) != MZ_OK)
         return MZ_PARAM_ERROR;

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -1763,7 +1763,9 @@ int32_t mz_zip_writer_copy_from_reader(void *handle, void *reader) {
 
         err = mz_zip_writer_entry_open(writer, file_info);
 
+#ifndef MZ_ZIP_NO_CRYPTO
         mz_crypt_sha_delete(&writer->hash);
+#endif
 
         if ((err == MZ_OK) &&
             (mz_zip_attrib_is_dir(writer->file_info.external_fa, writer->file_info.version_madeby) != MZ_OK)) {


### PR DESCRIPTION
This fixes https://github.com/zlib-ng/minizip-ng/issues/717 and includes sanitizer support to allow verification (i just borrowed the cmake code from zlib-ng).

Don't really know my way around the code, so the fix I provided may not be the best/proper way to do it.