### PR TITLE
CMake: fix SONAME for MZ_COMPAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,8 @@ endif()
 
 # Include compatibility layer
 if(MZ_COMPAT)
+    set(SOVERSION "1")
+
     set(FILE_H "zip.h")
     set(MZ_COMPAT_FILE "MZ_COMPAT_ZIP")
     configure_file(mz_compat_shim.h.in zip.h)


### PR DESCRIPTION
zlib's minizip has SONAME 1. MZ_COMPAT intends to provide ABI and API compatibility, so its SONAME should match.