### PR TITLE
Do not override error

### DIFF
--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1802,8 +1802,10 @@ static int32_t mz_zip_entry_open_int(void *handle, uint8_t raw, int16_t compress
             err = MZ_PARAM_ERROR;
     }
 
-    if (!zip->compress_stream)
-        err = MZ_MEM_ERROR;
+    if (err == MZ_OK) {
+        if (!zip->compress_stream)
+            err = MZ_MEM_ERROR;
+    }
 
     if (err == MZ_OK) {
         if (zip->open_mode & MZ_OPEN_MODE_WRITE) {


### PR DESCRIPTION
Only override the error value when `err` is equal to `MZ_OK`. Otherwise, when providing the wrong password for an encrypted file, the error value will be `MZ_MEM_ERROR` instead of `MZ_PASSWORD_ERROR`