### PR TITLE
Allow negative zstd compression level

### DIFF
--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -326,6 +326,7 @@ void *mz_stream_zstd_create(void) {
     if (zstd) {
         zstd->stream.vtbl = &mz_stream_zstd_vtbl;
         zstd->max_total_out = -1;
+        zstd->preset = ZSTD_CLEVEL_DEFAULT;
     }
     return zstd;
 }

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -50,7 +50,7 @@ typedef struct mz_stream_zstd_s {
     int64_t         max_total_in;
     int64_t         max_total_out;
     int8_t          initialized;
-    uint32_t        preset;
+    int32_t         preset;
 } mz_stream_zstd;
 
 /***************************************************************************/
@@ -312,10 +312,7 @@ int32_t mz_stream_zstd_set_prop_int64(void *stream, int32_t prop, int64_t value)
     mz_stream_zstd *zstd = (mz_stream_zstd *)stream;
     switch (prop) {
     case MZ_STREAM_PROP_COMPRESS_LEVEL:
-        if (value < 0)
-            zstd->preset = 6;
-        else
-            zstd->preset = (int16_t)value;
+        zstd->preset = (int32_t)value;
         return MZ_OK;
     case MZ_STREAM_PROP_TOTAL_IN_MAX:
         zstd->max_total_in = value;


### PR DESCRIPTION
It is not documented properly: https://github.com/facebook/zstd/issues/3133
But zstd compression level can go negative, and larger than int16_t as well: https://news.ycombinator.com/item?id=31428760 

Changed the preset type in the mz_stream_zstd to be a signed int32_t and removed < 0 clamping when setting level.