### PR TITLE
Fix Issue #706

### DIFF
--- a/mz_compat.c
+++ b/mz_compat.c
@@ -538,7 +538,7 @@ int zipOpenNewFileInZip3_64(zipFile file, const char *filename, const zip_filein
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, int compression_method, int level,
     int raw, int windowBits, int memLevel, int strategy, const char *password,
-    uint32_t crc_for_crypting, int zip64) {
+    unsigned long crc_for_crypting, int zip64) {
     return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
         extrafield_global, size_extrafield_global, comment, compression_method, level, raw, windowBits,
         memLevel, strategy, password, crc_for_crypting, MZ_VERSION_MADEBY, 0, zip64);

--- a/mz_compat.c
+++ b/mz_compat.c
@@ -121,7 +121,7 @@ static int32_t mz_stream_ioapi_read(void *stream, void *buf, int32_t size) {
     } else
         return MZ_PARAM_ERROR;
 
-    return zread(opaque, ioapi->handle, buf, size);
+    return (int32_t)zread(opaque, ioapi->handle, buf, size);
 }
 
 static int32_t mz_stream_ioapi_write(void *stream, const void *buf, int32_t size) {
@@ -142,7 +142,7 @@ static int32_t mz_stream_ioapi_write(void *stream, const void *buf, int32_t size
     } else
         return MZ_PARAM_ERROR;
 
-    written = zwrite(opaque, ioapi->handle, buf, size);
+    written = (int32_t)zwrite(opaque, ioapi->handle, buf, size);
     return written;
 }
 
@@ -596,7 +596,7 @@ int zipCloseFileInZipRaw64(zipFile file, uint64_t uncompressed_size, unsigned lo
     mz_compat *compat = (mz_compat *)file;
     if (!compat)
         return ZIP_PARAMERROR;
-    return mz_zip_entry_close_raw(compat->handle, (int64_t)uncompressed_size, crc32);
+    return mz_zip_entry_close_raw(compat->handle, (int64_t)uncompressed_size, (uint32_t)crc32);
 }
 
 int zipCloseFileInZip(zipFile file) {

--- a/mz_compat.h
+++ b/mz_compat.h
@@ -195,7 +195,7 @@ ZEXPORT int     zipOpenNewFileInZip3_64(zipFile file, const char *filename, cons
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, int compression_method, int level,
     int raw, int windowBits, int memLevel, int strategy, const char *password,
-    uint32_t crc_for_crypting, int zip64);
+    unsigned long crc_for_crypting, int zip64);
 ZEXPORT int     zipOpenNewFileInZip4(zipFile file, const char *filename, const zip_fileinfo *zipfi,
     const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
     uint16_t size_extrafield_global, const char *comment, int compression_method, int level,


### PR DESCRIPTION
Fixe Issue https://github.com/zlib-ng/minizip-ng/issues/706

Implicit conversion loses integer precision: 'unsigned long' to 'int32_t' (aka 'int') in line 124, 145 and 534
Implicit conversion loses integer precision: 'unsigned long' to 'uint32_t' (aka 'unsigned int') in line 599