### PR TITLE
Fix pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(MINIZIP_HDR
     mz_zip_rw.h)
 
 set(PC_PRIVATE_LIBS)
+set(PC_PRIVATE_DEPS)
 
 # Check for system includes
 check_include_file(stdint.h   HAVE_STDINT_H)
@@ -184,7 +185,7 @@ if(MZ_ZLIB)
         list(APPEND MINIZIP_LIB ${ZLIBNG_LIBRARIES})
         list(APPEND MINIZIP_LBD ${ZLIBNG_LIBRARY_DIRS})
 
-        set(PC_PRIVATE_LIBS " -lz-ng")
+        set(PC_PRIVATE_DEPS "zlib-ng")
         set(ZLIB_COMPAT OFF)
     elseif(ZLIB_FOUND AND NOT MZ_FORCE_FETCH_LIBS)
         message(STATUS "Using ZLIB ${ZLIB_VERSION}")
@@ -193,7 +194,7 @@ if(MZ_ZLIB)
         list(APPEND MINIZIP_LIB ${ZLIB_LIBRARIES})
         list(APPEND MINIZIP_LBD ${ZLIB_LIBRARY_DIRS})
 
-        set(PC_PRIVATE_LIBS " -lz")
+        set(PC_PRIVATE_DEPS "zlib")
         set(ZLIB_COMPAT ON)
     elseif(MZ_FETCH_LIBS)
         clone_repo(zlib https://github.com/madler/zlib)

--- a/minizip.pc.cmakein
+++ b/minizip.pc.cmakein
@@ -8,7 +8,7 @@ Name: @MINIZIP_TARGET@
 Description: Zip manipulation library
 Version: @VERSION@
 
-Requires: zlib
+Requires.private: @PC_PRIVATE_DEPS@
 Libs: -L${libdir} -L${sharedlibdir} -l@MINIZIP_TARGET@
 Libs.private:@PC_PRIVATE_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
If libz-ng is used the declared dependency on libz was wrong. Also it should be private if `Libs.private` is used. And if the libs are available as pkgconfig file we should use them instead of hardcoding liker flags. 