### PR TITLE
Support compression levels >= 10 and use zstd's internal default level.

### DIFF
--- a/minizip.c
+++ b/minizip.c
@@ -573,7 +573,7 @@ int main(int argc, const char *argv[]) {
             else if ((c == 'v') || (c == 'V'))
                 options.verbose = 1;
             else if ((c >= '0') && (c <= '9')) {
-                options.compress_level = (c - '0');
+                options.compress_level = (int16_t)atoi(&argv[i][1]);
                 if (options.compress_level == 0)
                     options.compress_method = MZ_COMPRESS_METHOD_STORE;
             } else if ((c == 'b') || (c == 'B'))

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -313,7 +313,7 @@ int32_t mz_stream_zstd_set_prop_int64(void *stream, int32_t prop, int64_t value)
     switch (prop) {
     case MZ_STREAM_PROP_COMPRESS_LEVEL:
         if (value < 0)
-            zstd->preset = 6;
+            zstd->preset = 0; // Use zstd default.
         else
             zstd->preset = (int16_t)value;
         return MZ_OK;


### PR DESCRIPTION
zstd supports regular compression levels 1 through 22.  This change enables minizip to accept command-line options of "-10" and above to set levels higher than 10.

This also changes minizip to send the special level of 0 when no command-line level option is specified, which indicates to use zstd's internal default level (currently 3, but potentially subject to change).

zstd also supports negative compression level values to enable "fast" compression.  These levels disable Huffman coding to achieve high bandwidth for streaming loads (comparable to LZ4).  I didn't attempt to support negative levels here as I'm not sure they're of much value in a non-streaming archive format.