### PR TITLE
Fix lzma compression level #731

### DIFF
--- a/mz_strm_lzma.c
+++ b/mz_strm_lzma.c
@@ -415,10 +415,10 @@ int32_t mz_stream_lzma_set_prop_int64(void *stream, int32_t prop, int64_t value)
     mz_stream_lzma *lzma = (mz_stream_lzma *)stream;
     switch (prop) {
     case MZ_STREAM_PROP_COMPRESS_LEVEL:
-        if (value >= 9)
-            lzma->preset = LZMA_PRESET_EXTREME;
-        else
+        if (value < 0 || value > 9)
             lzma->preset = LZMA_PRESET_DEFAULT;
+        else
+            lzma->preset = (uint32_t)value;
         break;
     case MZ_STREAM_PROP_COMPRESS_METHOD:
         lzma->method = (int16_t)value;


### PR DESCRIPTION
LZMA_PRESET_EXTREME is not a preset on its own but a flag which must be used together with a level. The difference between level 9 with and without the extreme flag also seems negligible, so this commit just passes through the level and maps -1 and invalid values to the default preset.

Closes #731