### PR TITLE
Reject overflows of zip header fields in minizip compat

### DIFF
--- a/mz_compat.c
+++ b/mz_compat.c
@@ -464,9 +464,9 @@ int zipOpenNewFileInZip5(zipFile file, const char *filename, const zip_fileinfo 
         return ZIP_PARAMERROR;
 
     // The filename and comment length must fit in 16 bits.
-    if ((filename != NULL) && (strlen(filename) > 0xffff))
+    if (filename && strlen(filename) > 0xffff)
         return ZIP_PARAMERROR;
-    if ((comment != NULL) && (strlen(comment) > 0xffff))
+    if (comment && strlen(comment) > 0xffff)
         return ZIP_PARAMERROR;
 
     memset(&file_info, 0, sizeof(file_info));

--- a/mz_compat.c
+++ b/mz_compat.c
@@ -463,6 +463,12 @@ int zipOpenNewFileInZip5(zipFile file, const char *filename, const zip_fileinfo 
     if (!compat)
         return ZIP_PARAMERROR;
 
+    // The filename and comment length must fit in 16 bits.
+    if ((filename != NULL) && (strlen(filename) > 0xffff))
+        return ZIP_PARAMERROR;
+    if ((comment != NULL) && (strlen(comment) > 0xffff))
+        return ZIP_PARAMERROR;
+
     memset(&file_info, 0, sizeof(file_info));
 
     if (zipfi) {


### PR DESCRIPTION
This PR applies https://github.com/madler/zlib/pull/843 to minizip compat to close #736. It applies the [patch](https://github.com/madler/zlib/pull/843.patch) provided by @zmodem, but removed the checks for unused extra fields.

> This checks the lengths of the file name, and comment that would be put in the zip headers, and rejects them if they are too long. They are each limited to 65535 bytes in length by the zip format. This also avoids possible buffer overflows if the provided fields are too long.