### PR TITLE
Fix unzLocateFile 3rd parameter

### DIFF
--- a/mz_compat.h
+++ b/mz_compat.h
@@ -308,7 +308,12 @@ typedef struct unz_file_info_s {
 
 /***************************************************************************/
 
-typedef int (*unzFileNameComparer)(unzFile file, const char *filename1, const char *filename2);
+/* Possible values:
+   0 - Uses OS default, e.g. Windows ignores case.
+   1 - Is case sensitive.
+   >= 2 - Ignore case.
+*/
+typedef int unzFileNameCase;
 typedef int (*unzIteratorFunction)(unzFile file);
 typedef int (*unzIteratorFunction2)(unzFile file, unz_file_info64 *pfile_info, char *filename,
     uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment,
@@ -349,7 +354,7 @@ ZEXPORT int     unzGetCurrentFileInfo64(unzFile file, unz_file_info64 * pfile_in
 
 ZEXPORT int     unzGoToFirstFile(unzFile file);
 ZEXPORT int     unzGoToNextFile(unzFile file);
-ZEXPORT int     unzLocateFile(unzFile file, const char *filename, unzFileNameComparer filename_compare_func);
+ZEXPORT int     unzLocateFile(unzFile file, const char *filename, unzFileNameCase filename_case);
 
 ZEXPORT int     unzGetLocalExtrafield(unzFile file, void *buf, unsigned int len);
 

--- a/test/test_compat.cc
+++ b/test/test_compat.cc
@@ -90,7 +90,7 @@ static void test_unzip_compat(unzFile unzip) {
     EXPECT_EQ(global_info64.number_disk_with_CD, 0)
         << "invalid disk with cd 64-bit";
 
-    EXPECT_EQ(err = unzLocateFile(unzip, "test.txt", (unzFileNameComparer)(void *)1), UNZ_OK)
+    EXPECT_EQ(err = unzLocateFile(unzip, "test.txt", 1), UNZ_OK)
         << "cannot locate test file (err: " << err << ")";
 
     EXPECT_EQ(err = unzGoToFirstFile(unzip), UNZ_OK);


### PR DESCRIPTION
Replace the previous type with one that is compatible with an int in order to be identical to the interface used in madler's zlib.

Fixes #745.