### PR TITLE
Silence -Wunused-but-set-variable warnings

### DIFF
--- a/mz_strm_bzip.c
+++ b/mz_strm_bzip.c
@@ -114,7 +114,6 @@ int32_t mz_stream_bzip_read(void *stream, void *buf, int32_t size) {
     uint64_t total_out_before = 0;
     uint64_t total_in_after = 0;
     uint64_t total_out_after = 0;
-    int32_t total_in = 0;
     int32_t total_out = 0;
     int32_t in_bytes = 0;
     int32_t out_bytes = 0;
@@ -157,7 +156,6 @@ int32_t mz_stream_bzip_read(void *stream, void *buf, int32_t size) {
         in_bytes = (int32_t)(total_in_before - total_in_after);
         out_bytes = (int32_t)(total_out_after - total_out_before);
 
-        total_in += in_bytes;
         total_out += out_bytes;
 
         bzip->total_in += in_bytes;

--- a/mz_strm_zstd.c
+++ b/mz_strm_zstd.c
@@ -107,7 +107,6 @@ int32_t mz_stream_zstd_read(void *stream, void *buf, int32_t size) {
     uint64_t total_in_after = 0;
     uint64_t total_out_before = 0;
     uint64_t total_out_after = 0;
-    int32_t total_in = 0;
     int32_t total_out = 0;
     int32_t in_bytes = 0;
     int32_t out_bytes = 0;
@@ -154,7 +153,6 @@ int32_t mz_stream_zstd_read(void *stream, void *buf, int32_t size) {
         in_bytes = (int32_t)(total_in_after - total_in_before);
         out_bytes = (int32_t)(total_out_after - total_out_before);
 
-        total_in += in_bytes;
         total_out += out_bytes;
 
         zstd->total_in += in_bytes;


### PR DESCRIPTION
```
/home/brad/tmp/minizip-ng/mz_strm_zstd.c:110:13: warning: variable 'total_in' set but not used [-Wunused-but-set-variable]
    int32_t total_in = 0;
            ^

/home/brad/tmp/minizip-ng/mz_strm_bzip.c:117:13: warning: variable 'total_in' set but not used [-Wunused-but-set-variable]
    int32_t total_in = 0;
            ^
```