### PR TITLE
Infinite loop occurs while decompressing zip multi-volume archive file

### DIFF
--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -104,8 +104,13 @@ static int32_t mz_stream_split_open_disk(void *stream, int32_t number_disk) {
     mz_stream_split_print("Split - Goto disk - %s (disk %" PRId32 ")\n", split->path_disk, number_disk);
 
     /* If disk part doesn't exist during reading then return MZ_EXIST_ERROR */
-    if (disk_part == MZ_OPEN_MODE_READ)
-        err = mz_os_file_exists(split->path_disk);
+    if (disk_part == MZ_OPEN_MODE_READ) {
+        if(strcmp(split->path_disk, split->path_cd) == 0) {
+            err = MZ_EXIST_ERROR;
+        } else {
+            err = mz_os_file_exists(split->path_disk);
+        }
+    }
 
     if (err == MZ_OK)
         err = mz_stream_open(split->stream.base, split->path_disk, split->mode);
@@ -241,7 +246,6 @@ int32_t mz_stream_split_read(void *stream, void *buf, int32_t size) {
             err = mz_stream_split_goto_disk(stream, split->current_disk + 1);
             if (err == MZ_EXIST_ERROR) {
                 split->current_disk = -1;
-                break;
             }
             if (err != MZ_OK)
                 return err;


### PR DESCRIPTION
## Problem-1
Decompress a zip multi-volume archive file without filename extension will cause an infinite loop.
payload: https://github.com/apache/commons-compress/blob/master/src/test/resources/COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.z01
change split_zip_created_by_zip.z01 filename to split_zip_created_by_zip, use minizip_cli to decompress this file(./minizip_cli -l /root/payloads/split_zip_created_by_zip) will cause an infinite loop.

## Problem-2
Decompress multi-volume zip archive files in recover mode will cause an infinite loop.
payload: https://github.com/apache/commons-compress/blob/master/src/test/resources/COMPRESS-477/split_zip_created_by_zip/split_zip_created_by_zip.zip
split_zip_created_by_zip.zip, split_zip_created_by_zip.z01 and split_zip_created_by_zip.z02 are split zip files, put these files in a directory(do not need to change their file names). Note mz_zip.c line 1451 and line 1455(to call mz_zip_recover_cd function) , and use the patched minizip_cli to decompress split_zip_created_by_zip.zip(./minizip_cli -l /root/payloads/split_zip_created_by_zip.zip) will occur infinite loop. 
I found this bug can only be triggered through mz_zip_recover_cd, split_zip_created_by_zip.zip not fail at mz_zip_read_cd, so if not note mz_zip.c can't trigger this bug. But if split_zip_created_by_zip.zip does not have a Central Directory, this bug can be triggered directly.