### PR TITLE
Expose zlib constants for backwards compat

### DIFF
--- a/compat/crypt.h
+++ b/compat/crypt.h
@@ -25,17 +25,15 @@
    Encryption is not supported.
 */
 
-#ifndef _ZLIB_H
-#  ifndef ZLIB_VERNUM
+#ifndef ZLIB_VERNUM
 /* No zlib */
 typedef uint32_t z_crc_t;
-#  elif (ZLIB_VERNUM & 0xf != 0xf) && (ZLIB_VERNUM < 0x1270)
+#elif (ZLIB_VERNUM & 0xf != 0xf) && (ZLIB_VERNUM < 0x1270)
 /* Define z_crc_t in zlib 1.2.6 and less */
 typedef unsigned long z_crc_t;
-#  elif (ZLIB_VERNUM & 0xf == 0xf) && (ZLIB_VERNUM < 0x12df)
+#elif (ZLIB_VERNUM & 0xf == 0xf) && (ZLIB_VERNUM < 0x12df)
 /* Define z_crc_t in zlib-ng 2.0.7 and less */
 typedef unsigned int z_crc_t;
-#  endif
 #endif
 
 #define CRC32(c, b) ((*(pcrc_32_tab + (((int)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))

--- a/compat/crypt.h
+++ b/compat/crypt.h
@@ -26,10 +26,15 @@
 */
 
 #ifndef _ZLIB_H
-#  if (ZLIB_VERNUM < 0x1270)
-    typedef unsigned long z_crc_t;
-#  else
-    typedef uint32_t z_crc_t;
+#  ifndef ZLIB_VERNUM
+/* No zlib */
+typedef uint32_t z_crc_t;
+#  elif (ZLIB_VERNUM & 0xf != 0xf) && (ZLIB_VERNUM < 0x1270)
+/* Define z_crc_t in zlib 1.2.6 and less */
+typedef unsigned long z_crc_t;
+#  elif (ZLIB_VERNUM & 0xf == 0xf) && (ZLIB_VERNUM < 0x12df)
+/* Define z_crc_t in zlib-ng 2.0.7 and less */
+typedef unsigned int z_crc_t;
 #  endif
 #endif
 

--- a/compat/ioapi.h
+++ b/compat/ioapi.h
@@ -5,8 +5,11 @@
 #include <stdint.h>
 
 #ifndef _ZLIB_H
-#  include "zlib.h"
-#endif
+#  if __has_include(<zlib.h>)
+#    include <zlib.h>
+#  elif __has_include(<zlib-ng.h>)
+#    include <zlib-ng.h>
+#  endif
 #endif
 
 typedef uint64_t ZPOS64_T;

--- a/compat/ioapi.h
+++ b/compat/ioapi.h
@@ -4,11 +4,11 @@
 
 #include <stdint.h>
 
-#ifndef _ZLIB_H
-#  if __has_include(<zlib.h>)
-#    include <zlib.h>
-#  elif __has_include(<zlib-ng.h>)
+#if !defined(_ZLIB_H) && !defined(ZLIB_H) && !defined(ZLIB_H_)
+#  if __has_include(<zlib-ng.h>)
 #    include <zlib-ng.h>
+#  elif __has_include(<zlib.h>)
+#    include <zlib.h>
 #  endif
 #endif
 

--- a/compat/ioapi.h
+++ b/compat/ioapi.h
@@ -7,12 +7,6 @@
 #ifndef _ZLIB_H
 #  include "zlib.h"
 #endif
-
-#ifndef Z_ERRNO
-#define Z_ERRNO                         (-1)
-#endif
-#ifndef Z_DEFLATED
-#define Z_DEFLATED                      (8)
 #endif
 
 typedef uint64_t ZPOS64_T;

--- a/compat/ioapi.h
+++ b/compat/ioapi.h
@@ -5,7 +5,14 @@
 #include <stdint.h>
 
 #ifndef _ZLIB_H
-//#include "zlib.h"
+#  include "zlib.h"
+#endif
+
+#ifndef Z_ERRNO
+#define Z_ERRNO                         (-1)
+#endif
+#ifndef Z_DEFLATED
+#define Z_DEFLATED                      (8)
 #endif
 
 typedef uint64_t ZPOS64_T;

--- a/compat/unzip.h
+++ b/compat/unzip.h
@@ -38,18 +38,6 @@ typedef void *unzFile;
 
 /***************************************************************************/
 
-#ifndef Z_ERRNO
-#define Z_ERRNO                         (-1)
-#endif
-#ifndef Z_DEFLATED
-#define Z_DEFLATED                      (8)
-#endif
-#ifndef Z_BZIP2ED
-#define Z_BZIP2ED                       (12)
-#endif
-
-/***************************************************************************/
-
 #define UNZ_OK                  (0)
 #define UNZ_END_OF_LIST_OF_FILE (-100)
 #define UNZ_ERRNO               (Z_ERRNO)

--- a/compat/zip.h
+++ b/compat/zip.h
@@ -38,16 +38,6 @@ typedef void *zipFile;
 
 /***************************************************************************/
 
-#ifndef Z_ERRNO
-#define Z_ERRNO                         (-1)
-#endif
-#ifndef Z_DEFLATED
-#define Z_DEFLATED                      (8)
-#endif
-#ifndef Z_BZIP2ED
-#define Z_BZIP2ED                       (12)
-#endif
-
 #define ZIP_OK            (0)
 #define ZIP_EOF           (0)
 #define ZIP_ERRNO         (Z_ERRNO)

--- a/mz_crypt.c
+++ b/mz_crypt.c
@@ -34,11 +34,15 @@ int32_t mz_crypt_rand(uint8_t *buf, int32_t size) {
 
 uint32_t mz_crypt_crc32_update(uint32_t value, const uint8_t *buf, int32_t size) {
 #if defined(HAVE_ZLIB)
-    /* Define z_crc_t in zlib 1.2.5 and less or if using zlib-ng */
-#  if (ZLIB_VERNUM < 0x1270)
-    typedef unsigned long z_crc_t;
-#  else
+#  ifndef ZLIB_VERNUM
+    /* HAVE_ZLIB but no ZLIB_VERNUM? */
     typedef uint32_t z_crc_t;
+#  elif (ZLIB_VERNUM & 0xf != 0xf) && (ZLIB_VERNUM < 0x1270)
+    /* Define z_crc_t in zlib 1.2.6 and less */
+    typedef unsigned long z_crc_t;
+#  elif (ZLIB_VERNUM & 0xf == 0xf) && (ZLIB_VERNUM < 0x12df)
+    /* Define z_crc_t in zlib-ng 2.0.7 and less */
+    typedef unsigned int z_crc_t;
 #  endif
     return (uint32_t)ZLIB_PREFIX(crc32)((z_crc_t)value, buf, (uInt)size);
 #elif defined(HAVE_LZMA)


### PR DESCRIPTION
Fix #747
Supersedes #750 (cc @brad0)

I re-did the PR to account for the recent refactor in 7df56f7cc8438b1b67c881cad049b29bf075bccd