### PR TITLE
align ZEXPORT definitions

### DIFF
--- a/compat/ioapi.h
+++ b/compat/ioapi.h
@@ -7,7 +7,7 @@
 typedef uint64_t ZPOS64_T;
 
 #ifndef ZEXPORT
-#  define ZEXPORT extern
+#  define ZEXPORT
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix #824.

Seems to have been a regression in 7df56f7cc8438b1b67c881cad049b29bf075bccd.