### PR TITLE
compatibility with Swift Package Manager

### DIFF
--- a/compat/ioapi.c
+++ b/compat/ioapi.c
@@ -1,6 +1,6 @@
-#include "mz.h"
-#include "mz_strm.h"
-#include "mz_strm_mem.h"
+#include "../mz.h"
+#include "../mz_strm.h"
+#include "../mz_strm_mem.h"
 
 #include "ioapi.h"
 

--- a/compat/unzip.c
+++ b/compat/unzip.c
@@ -10,11 +10,11 @@
    See the accompanying LICENSE file for the full text of the license.
 */
 
-#include "mz.h"
-#include "mz_os.h"
-#include "mz_strm.h"
-#include "mz_strm_os.h"
-#include "mz_zip.h"
+#include "../mz.h"
+#include "../mz_os.h"
+#include "../mz_strm.h"
+#include "../mz_strm_os.h"
+#include "../mz_zip.h"
 
 #include <stdio.h> /* SEEK */
 

--- a/compat/zip.c
+++ b/compat/zip.c
@@ -10,11 +10,11 @@
    See the accompanying LICENSE file for the full text of the license.
 */
 
-#include "mz.h"
-#include "mz_os.h"
-#include "mz_strm.h"
-#include "mz_strm_os.h"
-#include "mz_zip.h"
+#include "../mz.h"
+#include "../mz_os.h"
+#include "../mz_strm.h"
+#include "../mz_strm_os.h"
+#include "../mz_zip.h"
 
 #include "zip.h"
 


### PR DESCRIPTION
Swift Package Manager (which is supported by https://github.com/ZipArchive/ZipArchive and https://github.com/marmelroy/Zip), requires include paths to be matching the structure on disk.