### PR TITLE
Fix and improve fuzzers

### DIFF
--- a/test/fuzz/unzip_fuzzer.c
+++ b/test/fuzz/unzip_fuzzer.c
@@ -49,6 +49,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (!handle)
         return 1;
 
+    mz_zip_set_recover(handle, (size & 0xE0) == 0xE0);
     err = mz_zip_open(handle, stream, MZ_OPEN_MODE_READ);
 
     if (err == MZ_OK) {


### PR DESCRIPTION
1. `zip_fuzzer` didn't work as expected - the stream was always closed
2. Added password support for `zip_fuzzer`
3. Added `mz_zip_set_recover` support to `unzip_fuzzer`

As a result line coverage is improved by ~13%