### PR TITLE
Fix Windows Timestamps for Alternate Data Streams

### DIFF
--- a/mz_os_win32.c
+++ b/mz_os_win32.c
@@ -234,8 +234,7 @@ static void mz_os_unix_to_file_time(time_t unix_time, FILETIME *file_time) {
 }
 
 int32_t mz_os_get_file_date(const char *path, time_t *modified_date, time_t *accessed_date, time_t *creation_date) {
-    WIN32_FIND_DATAW ff32;
-    HANDLE handle = NULL;
+    WIN32_FILE_ATTRIBUTE_DATA wfad;
     wchar_t *path_wide = NULL;
     int32_t err = MZ_INTERNAL_ERROR;
 
@@ -245,20 +244,18 @@ int32_t mz_os_get_file_date(const char *path, time_t *modified_date, time_t *acc
     if (!path_wide)
         return MZ_PARAM_ERROR;
 
-    handle = FindFirstFileW(path_wide, &ff32);
-    free(path_wide);
-
-    if (handle != INVALID_HANDLE_VALUE) {
+    if (GetFileAttributesExW(path_wide, GetFileExInfoStandard, &wfad)) {
         if (modified_date)
-            mz_os_file_to_unix_time(ff32.ftLastWriteTime, modified_date);
+            mz_os_file_to_unix_time(wfad.ftLastWriteTime, modified_date);
         if (accessed_date)
-            mz_os_file_to_unix_time(ff32.ftLastAccessTime, accessed_date);
+            mz_os_file_to_unix_time(wfad.ftLastAccessTime, accessed_date);
         if (creation_date)
-            mz_os_file_to_unix_time(ff32.ftCreationTime, creation_date);
+            mz_os_file_to_unix_time(wfad.ftCreationTime, creation_date);
 
-        FindClose(handle);
         err = MZ_OK;
     }
+
+    free(path_wide);
 
     return err;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,10 @@ if(NOT MZ_COMPRESS_ONLY AND NOT MZ_DECOMPRESS_ONLY)
     list(APPEND TEST_SRCS test_stream_compress.cc)
 endif()
 
+if(MSVC)
+    list(APPEND TEST_SRCS test_file.cc)
+endif()
+
 add_executable(gtest_minizip test_main.cc ${TEST_SRCS})
 target_compile_definitions(gtest_minizip PRIVATE ${STDLIB_DEF} ${MINIZIP_DEF})
 target_include_directories(gtest_minizip PRIVATE

--- a/test/test_file.cc
+++ b/test/test_file.cc
@@ -1,4 +1,4 @@
-/* test_path.cc - Test path functionality
+/* test_file.cc - Test file functionality
    part of the minizip-ng project
 
    Copyright (C) Nathan Moinvaziri

--- a/test/test_file.cc
+++ b/test/test_file.cc
@@ -17,17 +17,17 @@
 
 TEST(os, get_file_date_ads) {
     
-    const std::string mainStreamName = "minizip_ads_test";
-    const std::string adsName = mainStreamName + ":ads";
-    const std::string adsContents = "Alternate Data Stream";
+    const std::string main_stream_name = "minizip_ads_test";
+    const std::string ads_name = main_stream_name + ":ads";
+    const std::string ads_contents = "Alternate Data Stream";
   
     // Create main stream
-    std::ofstream mainStream(mainStreamName);
-    mainStream.close();
+    std::ofstream main_stream(main_stream_name);
+    main_stream.close();
 
     // Attach ADS
-    std::ofstream ads(adsName);
-    ads << adsContents;
+    std::ofstream ads(ads_name);
+    ads << ads_contents;
     ads.close();
 
     // Get file date
@@ -35,9 +35,9 @@ TEST(os, get_file_date_ads) {
     time_t accessed_date = 0;
     time_t creation_date = 0;
 
-    EXPECT_EQ(MZ_OK, mz_os_get_file_date(adsName.c_str(), &modified_date, &accessed_date, &creation_date));
+    EXPECT_EQ(MZ_OK, mz_os_get_file_date(ads_name.c_str(), &modified_date, &accessed_date, &creation_date));
 
-    std::remove(mainStreamName.c_str());
+    std::remove(main_stream_name.c_str());
 
     ASSERT_GT(modified_date, 0);
     ASSERT_GT(accessed_date, 0);

--- a/test/test_file.cc
+++ b/test/test_file.cc
@@ -16,7 +16,6 @@
 #include <cstdio>
 
 TEST(os, get_file_date_ads) {
-    
     const std::string main_stream_name = "minizip_ads_test";
     const std::string ads_name = main_stream_name + ":ads";
     const std::string ads_contents = "Alternate Data Stream";

--- a/test/test_file.cc
+++ b/test/test_file.cc
@@ -1,0 +1,45 @@
+/* test_path.cc - Test path functionality
+   part of the minizip-ng project
+
+   Copyright (C) Nathan Moinvaziri
+     https://github.com/zlib-ng/minizip-ng
+
+   This program is distributed under the terms of the same license as zlib.
+   See the accompanying LICENSE file for the full text of the license.
+*/
+
+#include "mz.h"
+#include "mz_os.h"
+
+#include <gtest/gtest.h>
+#include <fstream>
+#include <cstdio>
+
+TEST(os, get_file_date_ads) {
+    
+    const std::string mainStreamName = "minizip_ads_test";
+    const std::string adsName = mainStreamName + ":ads";
+    const std::string adsContents = "Alternate Data Stream";
+  
+    // Create main stream
+    std::ofstream mainStream(mainStreamName);
+    mainStream.close();
+
+    // Attach ADS
+    std::ofstream ads(adsName);
+    ads << adsContents;
+    ads.close();
+
+    // Get file date
+    time_t modified_date = 0;
+    time_t accessed_date = 0;
+    time_t creation_date = 0;
+
+    EXPECT_EQ(MZ_OK, mz_os_get_file_date(adsName.c_str(), &modified_date, &accessed_date, &creation_date));
+
+    std::remove(mainStreamName.c_str());
+
+    ASSERT_GT(modified_date, 0);
+    ASSERT_GT(accessed_date, 0);
+    ASSERT_GT(creation_date, 0);
+}


### PR DESCRIPTION
_Should this target `develop` or `master`?_

## Summary

This PR changes `mz_os_get_file_date` to use `GetFileAttributesExW` instead of `FindFirstFileW`, because `FindFirstFileW` fails on Windows Alternate Data Streams.

## Description

`mz_os_get_file_date` uses `FindFirstFileW`, which doesn't support Windows Alternate Data Streams (ADS).  The failed return value of `mz_os_get_file_date` is not checked by `mz_zip_writer_add_file`.  When an ADS is compressed with `mz_zip_writer_add_file`, the resulting entry has all-zero timestamps.  When we attempted to extract this file using various applications (Windows Explorer, 7-Zip, Python), the CRC check would fail.  In python, the failure was [here](https://github.com/python/cpython/blob/8f93dd8a8f237b277abad20d566df90c5cbd7f1e/Lib/zipfile/__init__.py#L948-L949).  When we commented out that check, the file extracted correctly.

## Testing
The old implementation fails the new gtest:
```
Running main() from C:\git\minizip-ng\test\test_main.cc
Note: Google Test filter = *get_file_date_ads
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from os
[ RUN      ] os.get_file_date_ads
C:\git\minizip-ng\test\test_file.cc(38): error: Expected equality of these values:
  (0)
    Which is: 0
  mz_os_get_file_date(adsName.c_str(), &modified_date, &accessed_date, &creation_date)
    Which is: -104
C:\git\minizip-ng\test\test_file.cc(42): error: Expected: (modified_date) > (0), actual: 0 vs 0
[  FAILED  ] os.get_file_date_ads (2 ms)
[----------] 1 test from os (3 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] os.get_file_date_ads

 1 FAILED TEST
```

The new implementation passes:
```
Running main() from C:\git\minizip-ng\test\test_main.cc
Note: Google Test filter = *get_file_date_ads
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from os
[ RUN      ] os.get_file_date_ads
[       OK ] os.get_file_date_ads (1 ms)
[----------] 1 test from os (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.
```