### PR TITLE
Apply Clang format

### DIFF
--- a/minigzip.c
+++ b/minigzip.c
@@ -33,12 +33,13 @@ int32_t minigzip_banner(void) {
 }
 
 int32_t minigzip_help(void) {
-    printf("Usage: minigzip [-x] [-d] [-0 to -9] [files]\n\n" \
-           "  -x  Extract file\n" \
-           "  -d  Destination directory\n" \
-           "  -0  Store only\n" \
-           "  -1  Compress faster\n" \
-           "  -9  Compress better\n\n");
+    printf(
+        "Usage: minigzip [-x] [-d] [-0 to -9] [files]\n\n"
+        "  -x  Extract file\n"
+        "  -d  Destination directory\n"
+        "  -0  Store only\n"
+        "  -1  Compress faster\n"
+        "  -9  Compress better\n\n");
     return MZ_OK;
 }
 

--- a/minizip.c
+++ b/minizip.c
@@ -66,29 +66,31 @@ int32_t minizip_banner(void) {
 }
 
 int32_t minizip_help(void) {
-    printf("Usage: minizip [-x][-d dir|-l|-e][-o][-f][-y][-c cp][-a][-0 to -9][-b|-m|-t][-k 512][-p pwd][-s] file.zip [files]\n\n" \
-           "  -x  Extract files\n" \
-           "  -l  List files\n" \
-           "  -d  Destination directory\n" \
-           "  -e  Erase files\n" \
-           "  -o  Overwrite existing files\n" \
-           "  -c  File names use cp437 encoding (or specified codepage)\n" \
-           "  -a  Append to existing zip file\n" \
-           "  -i  Include full path of files\n" \
-           "  -f  Follow symbolic links\n" \
-           "  -y  Store symbolic links\n" \
-           "  -v  Verbose info\n" \
-           "  -0  Store only\n" \
-           "  -1  Compress faster\n" \
-           "  -9  Compress better\n" \
-           "  -k  Disk size in KB\n" \
-           "  -z  Zip central directory\n" \
-           "  -p  Encryption password\n" \
-           "  -s  AES encryption\n" \
-           "  -b  BZIP2 compression\n" \
-           "  -m  LZMA compression\n" \
-           "  -n  XZ compression\n" \
-           "  -t  ZSTD compression\n\n");
+    printf(
+        "Usage: minizip [-x][-d dir|-l|-e][-o][-f][-y][-c cp][-a][-0 to -9][-b|-m|-t][-k 512][-p pwd][-s] file.zip "
+        "[files]\n\n"
+        "  -x  Extract files\n"
+        "  -l  List files\n"
+        "  -d  Destination directory\n"
+        "  -e  Erase files\n"
+        "  -o  Overwrite existing files\n"
+        "  -c  File names use cp437 encoding (or specified codepage)\n"
+        "  -a  Append to existing zip file\n"
+        "  -i  Include full path of files\n"
+        "  -f  Follow symbolic links\n"
+        "  -y  Store symbolic links\n"
+        "  -v  Verbose info\n"
+        "  -0  Store only\n"
+        "  -1  Compress faster\n"
+        "  -9  Compress better\n"
+        "  -k  Disk size in KB\n"
+        "  -z  Zip central directory\n"
+        "  -p  Encryption password\n"
+        "  -s  AES encryption\n"
+        "  -b  BZIP2 compression\n"
+        "  -m  LZMA compression\n"
+        "  -n  XZ compression\n"
+        "  -t  ZSTD compression\n\n");
     return MZ_OK;
 }
 
@@ -102,7 +104,6 @@ int32_t minizip_list(const char *path) {
     const char *method = NULL;
     char crypt = ' ';
     void *reader = NULL;
-
 
     reader = mz_zip_reader_create();
     if (!reader)
@@ -240,7 +241,6 @@ int32_t minizip_add(const char *path, const char *password, minizip_opt *options
     int32_t err_close = MZ_OK;
     int32_t i = 0;
     const char *filename_in_zip = NULL;
-
 
     printf("Archive %s\n", path);
 
@@ -575,35 +575,35 @@ int main(int argc, const char *argv[]) {
                 if (options.compress_level == 0)
                     options.compress_method = MZ_COMPRESS_METHOD_STORE;
             } else if ((c == 'b') || (c == 'B'))
-#ifdef HAVE_BZIP2
+#  ifdef HAVE_BZIP2
                 options.compress_method = MZ_COMPRESS_METHOD_BZIP2;
-#else
+#  else
                 err = MZ_SUPPORT_ERROR;
-#endif
+#  endif
             else if ((c == 'm') || (c == 'M'))
-#ifdef HAVE_LZMA
+#  ifdef HAVE_LZMA
                 options.compress_method = MZ_COMPRESS_METHOD_LZMA;
-#else
+#  else
                 err = MZ_SUPPORT_ERROR;
-#endif
+#  endif
             else if ((c == 'n') || (c == 'N'))
-#if defined(HAVE_LZMA) || defined(HAVE_LIBCOMP)
+#  if defined(HAVE_LZMA) || defined(HAVE_LIBCOMP)
                 options.compress_method = MZ_COMPRESS_METHOD_XZ;
-#else
+#  else
                 err = MZ_SUPPORT_ERROR;
-#endif
+#  endif
             else if ((c == 't') || (c == 'T'))
-#ifdef HAVE_ZSTD
+#  ifdef HAVE_ZSTD
                 options.compress_method = MZ_COMPRESS_METHOD_ZSTD;
-#else
+#  else
                 err = MZ_SUPPORT_ERROR;
-#endif
+#  endif
             else if ((c == 's') || (c == 'S'))
-#ifdef HAVE_WZAES
+#  ifdef HAVE_WZAES
                 options.aes = 1;
-#else
+#  else
                 err = MZ_SUPPORT_ERROR;
-#endif
+#  endif
             else if (((c == 'c') || (c == 'C')) && (i + 1 < argc)) {
                 options.encoding = (int32_t)atoi(argv[i + 1]);
                 i += 1;
@@ -616,12 +616,12 @@ int main(int argc, const char *argv[]) {
                 printf("%s ", argv[i + 1]);
                 i += 1;
             } else if (((c == 'p') || (c == 'P')) && (i + 1 < argc)) {
-#ifndef MZ_ZIP_NO_ENCRYPTION
+#  ifndef MZ_ZIP_NO_ENCRYPTION
                 password = argv[i + 1];
                 printf("*** ");
-#else
+#  else
                 err = MZ_SUPPORT_ERROR;
-#endif
+#  endif
                 i += 1;
             }
         } else if (path_arg == 0)

--- a/mz.h
+++ b/mz.h
@@ -14,143 +14,142 @@
 /***************************************************************************/
 
 /* MZ_VERSION */
-#define MZ_VERSION                      ("4.0.8")
-#define MZ_VERSION_BUILD                (0x040008)
+#define MZ_VERSION       ("4.0.8")
+#define MZ_VERSION_BUILD (0x040008)
 
 /* MZ_ERROR */
-#define MZ_OK                           (0)  /* zlib */
-#define MZ_STREAM_ERROR                 (-1) /* zlib */
-#define MZ_DATA_ERROR                   (-3) /* zlib */
-#define MZ_MEM_ERROR                    (-4) /* zlib */
-#define MZ_BUF_ERROR                    (-5) /* zlib */
-#define MZ_VERSION_ERROR                (-6) /* zlib */
+#define MZ_OK             (0)  /* zlib */
+#define MZ_STREAM_ERROR   (-1) /* zlib */
+#define MZ_DATA_ERROR     (-3) /* zlib */
+#define MZ_MEM_ERROR      (-4) /* zlib */
+#define MZ_BUF_ERROR      (-5) /* zlib */
+#define MZ_VERSION_ERROR  (-6) /* zlib */
 
-#define MZ_END_OF_LIST                  (-100)
-#define MZ_END_OF_STREAM                (-101)
+#define MZ_END_OF_LIST    (-100)
+#define MZ_END_OF_STREAM  (-101)
 
-#define MZ_PARAM_ERROR                  (-102)
-#define MZ_FORMAT_ERROR                 (-103)
-#define MZ_INTERNAL_ERROR               (-104)
-#define MZ_CRC_ERROR                    (-105)
-#define MZ_CRYPT_ERROR                  (-106)
-#define MZ_EXIST_ERROR                  (-107)
-#define MZ_PASSWORD_ERROR               (-108)
-#define MZ_SUPPORT_ERROR                (-109)
-#define MZ_HASH_ERROR                   (-110)
-#define MZ_OPEN_ERROR                   (-111)
-#define MZ_CLOSE_ERROR                  (-112)
-#define MZ_SEEK_ERROR                   (-113)
-#define MZ_TELL_ERROR                   (-114)
-#define MZ_READ_ERROR                   (-115)
-#define MZ_WRITE_ERROR                  (-116)
-#define MZ_SIGN_ERROR                   (-117)
-#define MZ_SYMLINK_ERROR                (-118)
+#define MZ_PARAM_ERROR    (-102)
+#define MZ_FORMAT_ERROR   (-103)
+#define MZ_INTERNAL_ERROR (-104)
+#define MZ_CRC_ERROR      (-105)
+#define MZ_CRYPT_ERROR    (-106)
+#define MZ_EXIST_ERROR    (-107)
+#define MZ_PASSWORD_ERROR (-108)
+#define MZ_SUPPORT_ERROR  (-109)
+#define MZ_HASH_ERROR     (-110)
+#define MZ_OPEN_ERROR     (-111)
+#define MZ_CLOSE_ERROR    (-112)
+#define MZ_SEEK_ERROR     (-113)
+#define MZ_TELL_ERROR     (-114)
+#define MZ_READ_ERROR     (-115)
+#define MZ_WRITE_ERROR    (-116)
+#define MZ_SIGN_ERROR     (-117)
+#define MZ_SYMLINK_ERROR  (-118)
 
 /* MZ_OPEN */
-#define MZ_OPEN_MODE_READ               (0x01)
-#define MZ_OPEN_MODE_WRITE              (0x02)
-#define MZ_OPEN_MODE_READWRITE          (MZ_OPEN_MODE_READ | MZ_OPEN_MODE_WRITE)
-#define MZ_OPEN_MODE_APPEND             (0x04)
-#define MZ_OPEN_MODE_CREATE             (0x08)
-#define MZ_OPEN_MODE_EXISTING           (0x10)
+#define MZ_OPEN_MODE_READ      (0x01)
+#define MZ_OPEN_MODE_WRITE     (0x02)
+#define MZ_OPEN_MODE_READWRITE (MZ_OPEN_MODE_READ | MZ_OPEN_MODE_WRITE)
+#define MZ_OPEN_MODE_APPEND    (0x04)
+#define MZ_OPEN_MODE_CREATE    (0x08)
+#define MZ_OPEN_MODE_EXISTING  (0x10)
 
 /* MZ_SEEK */
-#define MZ_SEEK_SET                     (0)
-#define MZ_SEEK_CUR                     (1)
-#define MZ_SEEK_END                     (2)
+#define MZ_SEEK_SET (0)
+#define MZ_SEEK_CUR (1)
+#define MZ_SEEK_END (2)
 
 /* MZ_COMPRESS */
-#define MZ_COMPRESS_METHOD_STORE        (0)
-#define MZ_COMPRESS_METHOD_DEFLATE      (8)
-#define MZ_COMPRESS_METHOD_BZIP2        (12)
-#define MZ_COMPRESS_METHOD_LZMA         (14)
-#define MZ_COMPRESS_METHOD_ZSTD         (93)
-#define MZ_COMPRESS_METHOD_XZ           (95)
-#define MZ_COMPRESS_METHOD_AES          (99)
+#define MZ_COMPRESS_METHOD_STORE   (0)
+#define MZ_COMPRESS_METHOD_DEFLATE (8)
+#define MZ_COMPRESS_METHOD_BZIP2   (12)
+#define MZ_COMPRESS_METHOD_LZMA    (14)
+#define MZ_COMPRESS_METHOD_ZSTD    (93)
+#define MZ_COMPRESS_METHOD_XZ      (95)
+#define MZ_COMPRESS_METHOD_AES     (99)
 
-#define MZ_COMPRESS_LEVEL_DEFAULT       (-1)
-#define MZ_COMPRESS_LEVEL_FAST          (2)
-#define MZ_COMPRESS_LEVEL_NORMAL        (6)
-#define MZ_COMPRESS_LEVEL_BEST          (9)
+#define MZ_COMPRESS_LEVEL_DEFAULT  (-1)
+#define MZ_COMPRESS_LEVEL_FAST     (2)
+#define MZ_COMPRESS_LEVEL_NORMAL   (6)
+#define MZ_COMPRESS_LEVEL_BEST     (9)
 
 /* MZ_ZIP_FLAG */
-#define MZ_ZIP_FLAG_ENCRYPTED           (1 << 0)
-#define MZ_ZIP_FLAG_LZMA_EOS_MARKER     (1 << 1)
-#define MZ_ZIP_FLAG_DEFLATE_MAX         (1 << 1)
-#define MZ_ZIP_FLAG_DEFLATE_NORMAL      (0)
-#define MZ_ZIP_FLAG_DEFLATE_FAST        (1 << 2)
-#define MZ_ZIP_FLAG_DEFLATE_SUPER_FAST  (MZ_ZIP_FLAG_DEFLATE_FAST | \
-                                         MZ_ZIP_FLAG_DEFLATE_MAX)
-#define MZ_ZIP_FLAG_DATA_DESCRIPTOR     (1 << 3)
-#define MZ_ZIP_FLAG_UTF8                (1 << 11)
-#define MZ_ZIP_FLAG_MASK_LOCAL_INFO     (1 << 13)
+#define MZ_ZIP_FLAG_ENCRYPTED          (1 << 0)
+#define MZ_ZIP_FLAG_LZMA_EOS_MARKER    (1 << 1)
+#define MZ_ZIP_FLAG_DEFLATE_MAX        (1 << 1)
+#define MZ_ZIP_FLAG_DEFLATE_NORMAL     (0)
+#define MZ_ZIP_FLAG_DEFLATE_FAST       (1 << 2)
+#define MZ_ZIP_FLAG_DEFLATE_SUPER_FAST (MZ_ZIP_FLAG_DEFLATE_FAST | MZ_ZIP_FLAG_DEFLATE_MAX)
+#define MZ_ZIP_FLAG_DATA_DESCRIPTOR    (1 << 3)
+#define MZ_ZIP_FLAG_UTF8               (1 << 11)
+#define MZ_ZIP_FLAG_MASK_LOCAL_INFO    (1 << 13)
 
 /* MZ_ZIP_EXTENSION */
-#define MZ_ZIP_EXTENSION_ZIP64          (0x0001)
-#define MZ_ZIP_EXTENSION_NTFS           (0x000a)
-#define MZ_ZIP_EXTENSION_AES            (0x9901)
-#define MZ_ZIP_EXTENSION_UNIX1          (0x000d)
-#define MZ_ZIP_EXTENSION_SIGN           (0x10c5)
-#define MZ_ZIP_EXTENSION_HASH           (0x1a51)
-#define MZ_ZIP_EXTENSION_CDCD           (0xcdcd)
+#define MZ_ZIP_EXTENSION_ZIP64 (0x0001)
+#define MZ_ZIP_EXTENSION_NTFS  (0x000a)
+#define MZ_ZIP_EXTENSION_AES   (0x9901)
+#define MZ_ZIP_EXTENSION_UNIX1 (0x000d)
+#define MZ_ZIP_EXTENSION_SIGN  (0x10c5)
+#define MZ_ZIP_EXTENSION_HASH  (0x1a51)
+#define MZ_ZIP_EXTENSION_CDCD  (0xcdcd)
 
 /* MZ_ZIP64 */
-#define MZ_ZIP64_AUTO                   (0)
-#define MZ_ZIP64_FORCE                  (1)
-#define MZ_ZIP64_DISABLE                (2)
+#define MZ_ZIP64_AUTO    (0)
+#define MZ_ZIP64_FORCE   (1)
+#define MZ_ZIP64_DISABLE (2)
 
 /* MZ_HOST_SYSTEM */
-#define MZ_HOST_SYSTEM(VERSION_MADEBY)  ((uint8_t)(VERSION_MADEBY >> 8))
-#define MZ_HOST_SYSTEM_MSDOS            (0)
-#define MZ_HOST_SYSTEM_UNIX             (3)
-#define MZ_HOST_SYSTEM_WINDOWS_NTFS     (10)
-#define MZ_HOST_SYSTEM_RISCOS           (13)
-#define MZ_HOST_SYSTEM_OSX_DARWIN       (19)
+#define MZ_HOST_SYSTEM(VERSION_MADEBY) ((uint8_t)(VERSION_MADEBY >> 8))
+#define MZ_HOST_SYSTEM_MSDOS           (0)
+#define MZ_HOST_SYSTEM_UNIX            (3)
+#define MZ_HOST_SYSTEM_WINDOWS_NTFS    (10)
+#define MZ_HOST_SYSTEM_RISCOS          (13)
+#define MZ_HOST_SYSTEM_OSX_DARWIN      (19)
 
 /* MZ_PKCRYPT */
-#define MZ_PKCRYPT_HEADER_SIZE          (12)
+#define MZ_PKCRYPT_HEADER_SIZE (12)
 
 /* MZ_AES */
-#define MZ_AES_VERSION                  (1)
-#define MZ_AES_MODE_ECB                 (0)
-#define MZ_AES_MODE_CBC                 (1)
-#define MZ_AES_MODE_GCM                 (2)
-#define MZ_AES_STRENGTH_128             (1)
-#define MZ_AES_STRENGTH_192             (2)
-#define MZ_AES_STRENGTH_256             (3)
-#define MZ_AES_KEY_LENGTH_MAX           (32)
-#define MZ_AES_BLOCK_SIZE               (16)
-#define MZ_AES_FOOTER_SIZE              (10)
+#define MZ_AES_VERSION        (1)
+#define MZ_AES_MODE_ECB       (0)
+#define MZ_AES_MODE_CBC       (1)
+#define MZ_AES_MODE_GCM       (2)
+#define MZ_AES_STRENGTH_128   (1)
+#define MZ_AES_STRENGTH_192   (2)
+#define MZ_AES_STRENGTH_256   (3)
+#define MZ_AES_KEY_LENGTH_MAX (32)
+#define MZ_AES_BLOCK_SIZE     (16)
+#define MZ_AES_FOOTER_SIZE    (10)
 
 /* MZ_HASH */
-#define MZ_HASH_MD5                     (10)
-#define MZ_HASH_MD5_SIZE                (16)
-#define MZ_HASH_SHA1                    (20)
-#define MZ_HASH_SHA1_SIZE               (20)
-#define MZ_HASH_SHA224                  (22)
-#define MZ_HASH_SHA224_SIZE             (28)
-#define MZ_HASH_SHA256                  (23)
-#define MZ_HASH_SHA256_SIZE             (32)
-#define MZ_HASH_SHA384                  (24)
-#define MZ_HASH_SHA384_SIZE             (48)
-#define MZ_HASH_SHA512                  (25)
-#define MZ_HASH_SHA512_SIZE             (64)
-#define MZ_HASH_MAX_SIZE                (256)
+#define MZ_HASH_MD5         (10)
+#define MZ_HASH_MD5_SIZE    (16)
+#define MZ_HASH_SHA1        (20)
+#define MZ_HASH_SHA1_SIZE   (20)
+#define MZ_HASH_SHA224      (22)
+#define MZ_HASH_SHA224_SIZE (28)
+#define MZ_HASH_SHA256      (23)
+#define MZ_HASH_SHA256_SIZE (32)
+#define MZ_HASH_SHA384      (24)
+#define MZ_HASH_SHA384_SIZE (48)
+#define MZ_HASH_SHA512      (25)
+#define MZ_HASH_SHA512_SIZE (64)
+#define MZ_HASH_MAX_SIZE    (256)
 
 /* MZ_ENCODING */
-#define MZ_ENCODING_CODEPAGE_437        (437)
-#define MZ_ENCODING_CODEPAGE_932        (932)
-#define MZ_ENCODING_CODEPAGE_936        (936)
-#define MZ_ENCODING_CODEPAGE_950        (950)
-#define MZ_ENCODING_UTF8                (65001)
+#define MZ_ENCODING_CODEPAGE_437 (437)
+#define MZ_ENCODING_CODEPAGE_932 (932)
+#define MZ_ENCODING_CODEPAGE_936 (936)
+#define MZ_ENCODING_CODEPAGE_950 (950)
+#define MZ_ENCODING_UTF8         (65001)
 
 /* MZ_UTILITY */
-#define MZ_UNUSED(SYMBOL)               ((void)SYMBOL)
+#define MZ_UNUSED(SYMBOL) ((void)SYMBOL)
 
 #if defined(_WIN32) && defined(MZ_EXPORTS)
-#define MZ_EXPORT __declspec(dllexport)
+#  define MZ_EXPORT __declspec(dllexport)
 #else
-#define MZ_EXPORT
+#  define MZ_EXPORT
 #endif
 
 /***************************************************************************/

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -56,15 +56,15 @@
 /***************************************************************************/
 
 #define MZ_ZIP_MAGIC_LOCALHEADER        (0x04034b50)
-#define MZ_ZIP_MAGIC_LOCALHEADERU8      { 0x50, 0x4b, 0x03, 0x04 }
+#define MZ_ZIP_MAGIC_LOCALHEADERU8      {0x50, 0x4b, 0x03, 0x04}
 #define MZ_ZIP_MAGIC_CENTRALHEADER      (0x02014b50)
-#define MZ_ZIP_MAGIC_CENTRALHEADERU8    { 0x50, 0x4b, 0x01, 0x02 }
+#define MZ_ZIP_MAGIC_CENTRALHEADERU8    {0x50, 0x4b, 0x01, 0x02}
 #define MZ_ZIP_MAGIC_ENDHEADER          (0x06054b50)
-#define MZ_ZIP_MAGIC_ENDHEADERU8        { 0x50, 0x4b, 0x05, 0x06 }
+#define MZ_ZIP_MAGIC_ENDHEADERU8        {0x50, 0x4b, 0x05, 0x06}
 #define MZ_ZIP_MAGIC_ENDHEADER64        (0x06064b50)
 #define MZ_ZIP_MAGIC_ENDLOCHEADER64     (0x07064b50)
 #define MZ_ZIP_MAGIC_DATADESCRIPTOR     (0x08074b50)
-#define MZ_ZIP_MAGIC_DATADESCRIPTORU8   { 0x50, 0x4b, 0x07, 0x08 }
+#define MZ_ZIP_MAGIC_DATADESCRIPTORU8   {0x50, 0x4b, 0x07, 0x08}
 
 #define MZ_ZIP_SIZE_LD_ITEM             (30)
 #define MZ_ZIP_SIZE_CD_ITEM             (46)
@@ -75,7 +75,7 @@
 #define MZ_ZIP_UNCOMPR_SIZE64_CUSHION   (2 * 1024 * 1024)
 
 #ifndef MZ_ZIP_EOCD_MAX_BACK
-#define MZ_ZIP_EOCD_MAX_BACK            (1 << 20)
+#  define MZ_ZIP_EOCD_MAX_BACK (1 << 20)
 #endif
 
 /***************************************************************************/
@@ -84,36 +84,36 @@ typedef struct mz_zip_s {
     mz_zip_file file_info;
     mz_zip_file local_file_info;
 
-    void *stream;                   /* main stream */
-    void *cd_stream;                /* pointer to the stream with the cd */
-    void *cd_mem_stream;            /* memory stream for central directory */
-    void *compress_stream;          /* compression stream */
-    void *crypt_stream;             /* encryption stream */
-    void *file_info_stream;         /* memory stream for storing file info */
-    void *local_file_info_stream;   /* memory stream for storing local file info */
+    void *stream;                 /* main stream */
+    void *cd_stream;              /* pointer to the stream with the cd */
+    void *cd_mem_stream;          /* memory stream for central directory */
+    void *compress_stream;        /* compression stream */
+    void *crypt_stream;           /* encryption stream */
+    void *file_info_stream;       /* memory stream for storing file info */
+    void *local_file_info_stream; /* memory stream for storing local file info */
 
-    int32_t  open_mode;
-    uint8_t  recover;
-    uint8_t  data_descriptor;
+    int32_t open_mode;
+    uint8_t recover;
+    uint8_t data_descriptor;
 
-    uint32_t disk_number_with_cd;   /* number of the disk with the central dir */
-    int64_t  disk_offset_shift;     /* correction for zips that have wrong offset start of cd */
+    uint32_t disk_number_with_cd; /* number of the disk with the central dir */
+    int64_t disk_offset_shift;    /* correction for zips that have wrong offset start of cd */
 
-    int64_t  cd_start_pos;          /* pos of the first file in the central dir stream */
-    int64_t  cd_current_pos;        /* pos of the current file in the central dir */
-    int64_t  cd_offset;             /* offset of start of central directory */
-    int64_t  cd_size;               /* size of the central directory */
-    uint32_t cd_signature;          /* signature of central directory */
+    int64_t cd_start_pos;   /* pos of the first file in the central dir stream */
+    int64_t cd_current_pos; /* pos of the current file in the central dir */
+    int64_t cd_offset;      /* offset of start of central directory */
+    int64_t cd_size;        /* size of the central directory */
+    uint32_t cd_signature;  /* signature of central directory */
 
-    uint8_t  entry_scanned;         /* entry header information read ok */
-    uint8_t  entry_opened;          /* entry is open for read/write */
-    uint8_t  entry_raw;             /* entry opened with raw mode */
-    uint32_t entry_crc32;           /* entry crc32  */
+    uint8_t entry_scanned; /* entry header information read ok */
+    uint8_t entry_opened;  /* entry is open for read/write */
+    uint8_t entry_raw;     /* entry opened with raw mode */
+    uint32_t entry_crc32;  /* entry crc32  */
 
     uint64_t number_entry;
 
     uint16_t version_madeby;
-    char     *comment;
+    char *comment;
 } mz_zip;
 
 /***************************************************************************/
@@ -188,8 +188,7 @@ static int32_t mz_zip_search_zip64_eocd(void *stream, const int64_t end_central_
 
 #ifdef HAVE_PKCRYPT
 /* Get PKWARE traditional encryption verifier */
-static uint16_t mz_zip_get_pk_verify(uint32_t dos_date, uint64_t crc, uint16_t flag)
-{
+static uint16_t mz_zip_get_pk_verify(uint32_t dos_date, uint64_t crc, uint16_t flag) {
     /* Info-ZIP modification to ZipCrypto format: if bit 3 of the general
      * purpose bit flag is set, it uses high byte of 16-bit File Time. */
     if (flag & MZ_ZIP_FLAG_DATA_DESCRIPTOR)
@@ -1326,16 +1325,17 @@ static int32_t mz_zip_recover_cd(void *handle) {
             }
 
             if (local_file_info.flag & MZ_ZIP_FLAG_DATA_DESCRIPTOR || local_file_info.compressed_size == 0) {
-                /* Search backwards for the descriptor, seeking too far back will be incorrect if compressed size is small */
+                /* Search backwards for the descriptor, seeking too far back will be incorrect if compressed size is
+                 * small */
                 err = mz_stream_find_reverse(zip->stream, (const void *)descriptor_magic, sizeof(descriptor_magic),
-                            MZ_ZIP_SIZE_MAX_DATA_DESCRIPTOR, &descriptor_pos);
+                                             MZ_ZIP_SIZE_MAX_DATA_DESCRIPTOR, &descriptor_pos);
                 if (err == MZ_OK) {
-                    if (mz_zip_extrafield_contains(local_file_info.extrafield,
-                        local_file_info.extrafield_size, MZ_ZIP_EXTENSION_ZIP64, NULL) == MZ_OK)
+                    if (mz_zip_extrafield_contains(local_file_info.extrafield, local_file_info.extrafield_size,
+                                                   MZ_ZIP_EXTENSION_ZIP64, NULL) == MZ_OK)
                         zip64 = 1;
 
-                    err = mz_zip_entry_read_descriptor(zip->stream, zip64, &crc32,
-                        &compressed_size, &uncompressed_size);
+                    err =
+                        mz_zip_entry_read_descriptor(zip->stream, zip64, &crc32, &compressed_size, &uncompressed_size);
 
                     if (err == MZ_OK) {
                         if (local_file_info.crc == 0)
@@ -2737,7 +2737,8 @@ uint32_t mz_zip_tm_to_dosdate(const struct tm *ptm) {
     if (mz_zip_invalid_date(&fixed_tm))
         return 0;
 
-    return (((uint32_t)fixed_tm.tm_mday + (32 * ((uint32_t)fixed_tm.tm_mon + 1)) + (512 * (uint32_t)fixed_tm.tm_year)) << 16) |
+    return (((uint32_t)fixed_tm.tm_mday + (32 * ((uint32_t)fixed_tm.tm_mon + 1)) + (512 * (uint32_t)fixed_tm.tm_year))
+            << 16) |
         (((uint32_t)fixed_tm.tm_sec / 2) + (32 * (uint32_t)fixed_tm.tm_min) + (2048 * (uint32_t)fixed_tm.tm_hour));
 }
 

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -23,9 +23,9 @@
 
 /***************************************************************************/
 
-#define MZ_DEFAULT_PROGRESS_INTERVAL    (1000u)
+#define MZ_DEFAULT_PROGRESS_INTERVAL (1000u)
 
-#define MZ_ZIP_CD_FILENAME              ("__cdcd__")
+#define MZ_ZIP_CD_FILENAME           ("__cdcd__")
 
 /***************************************************************************/
 
@@ -435,8 +435,8 @@ int32_t mz_zip_reader_entry_close(void *handle) {
         mz_crypt_sha_end(reader->hash, computed_hash, sizeof(computed_hash));
         mz_crypt_sha_delete(&reader->hash);
 
-        err_hash = mz_zip_reader_entry_get_hash(handle, reader->hash_algorithm, expected_hash,
-            reader->hash_digest_size);
+        err_hash =
+            mz_zip_reader_entry_get_hash(handle, reader->hash_algorithm, expected_hash, reader->hash_digest_size);
 
         if (err_hash == MZ_OK) {
             /* Verify expected hash against computed hash */
@@ -754,8 +754,9 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
 
     if (err == MZ_OK) {
         /* Set file attributes for the correct system */
-        err_attrib = mz_zip_attrib_convert(MZ_HOST_SYSTEM(reader->file_info->version_madeby),
-            reader->file_info->external_fa, MZ_VERSION_MADEBY_HOST_SYSTEM, &target_attrib);
+        err_attrib =
+            mz_zip_attrib_convert(MZ_HOST_SYSTEM(reader->file_info->version_madeby), reader->file_info->external_fa,
+                                  MZ_VERSION_MADEBY_HOST_SYSTEM, &target_attrib);
 
         if (err_attrib == MZ_OK)
             mz_os_set_file_attribs(pathwfs, target_attrib);
@@ -1400,8 +1401,8 @@ int32_t mz_zip_writer_entry_close(void *handle) {
 
     if (err == MZ_OK) {
         if (writer->raw)
-            err = mz_zip_entry_close_raw(writer->zip_handle, writer->file_info.uncompressed_size,
-                writer->file_info.crc);
+            err =
+                mz_zip_entry_close_raw(writer->zip_handle, writer->file_info.uncompressed_size, writer->file_info.crc);
         else
             err = mz_zip_entry_close(writer->zip_handle);
     }

--- a/test/test_compat.cc
+++ b/test/test_compat.cc
@@ -27,8 +27,9 @@ static void test_zip_compat(zipFile zip, const char *filename, int32_t level) {
     memset(&file_info, 0, sizeof(file_info));
     file_info.dosDate = mz_zip_time_t_to_dos_date(1588561637);
 
-    EXPECT_EQ(err = zipOpenNewFileInZip(zip, filename, &file_info, NULL, 0, NULL, 0, "test local comment",
-        Z_DEFLATED, level), ZIP_OK)
+    EXPECT_EQ(
+        err = zipOpenNewFileInZip(zip, filename, &file_info, NULL, 0, NULL, 0, "test local comment", Z_DEFLATED, level),
+        ZIP_OK)
         << "failed to open new file in zip (err: " << err << ")";
     if (err != ZIP_OK)
         return;
@@ -36,8 +37,7 @@ static void test_zip_compat(zipFile zip, const char *filename, int32_t level) {
     EXPECT_EQ(err = zipWriteInFileInZip(zip, buffer, (uint32_t)strlen(buffer)), ZIP_OK)
         << "failed to write to file in zip (err: " << err << ")";
 
-    EXPECT_EQ(err = zipCloseFileInZip(zip), ZIP_OK)
-        << "failed to close file in zip (err: " << err << ")";
+    EXPECT_EQ(err = zipCloseFileInZip(zip), ZIP_OK) << "failed to close file in zip (err: " << err << ")";
 }
 
 TEST(compat, zip) {
@@ -78,23 +78,17 @@ static void test_unzip_compat(unzFile unzip) {
 
     EXPECT_STREQ(comment, "test global comment");
 
-    EXPECT_EQ(err = unzGetGlobalInfo(unzip, &global_info), UNZ_OK)
-        << "global info (err: " << err << ")";
+    EXPECT_EQ(err = unzGetGlobalInfo(unzip, &global_info), UNZ_OK) << "global info (err: " << err << ")";
     EXPECT_EQ(err = unzGetGlobalInfo64(unzip, &global_info64), UNZ_OK)
         << "global info l info 64-bit (err: " << err << ")";
 
-    EXPECT_EQ(global_info.number_entry, 2)
-        << "invalid number of entries";
-    EXPECT_EQ(global_info64.number_entry, 2)
-        << "invalid number of entries 64-bit";
+    EXPECT_EQ(global_info.number_entry, 2) << "invalid number of entries";
+    EXPECT_EQ(global_info64.number_entry, 2) << "invalid number of entries 64-bit";
 
-    EXPECT_EQ(global_info.number_disk_with_CD, 0)
-        << "invalid disk with cd";
-    EXPECT_EQ(global_info64.number_disk_with_CD, 0)
-        << "invalid disk with cd 64-bit";
+    EXPECT_EQ(global_info.number_disk_with_CD, 0) << "invalid disk with cd";
+    EXPECT_EQ(global_info64.number_disk_with_CD, 0) << "invalid disk with cd 64-bit";
 
-    EXPECT_EQ(err = unzLocateFile(unzip, "test.txt", 1), UNZ_OK)
-        << "cannot locate test file (err: " << err << ")";
+    EXPECT_EQ(err = unzLocateFile(unzip, "test.txt", 1), UNZ_OK) << "cannot locate test file (err: " << err << ")";
 
     EXPECT_EQ(err = unzGoToFirstFile(unzip), UNZ_OK);
     if (err != UNZ_OK)
@@ -102,73 +96,66 @@ static void test_unzip_compat(unzFile unzip) {
 
     EXPECT_EQ(err = unzGetCurrentFileInfo64(unzip, &file_info64, filename, sizeof(filename), NULL, 0, NULL, 0), UNZ_OK)
         << "failed to get current file info 64-bit (err: " << err << ")";
-    EXPECT_EQ(err = unzOpenCurrentFile(unzip), UNZ_OK)
-        << "failed to open current file (err: " << err << ")";
+    EXPECT_EQ(err = unzOpenCurrentFile(unzip), UNZ_OK) << "failed to open current file (err: " << err << ")";
 
     EXPECT_EQ(bytes_read = unzReadCurrentFile(unzip, buffer, sizeof(buffer)), (int32_t)strlen(test_data))
         << "failed to read zip entry data (err: " << err << ")";
 
-    EXPECT_EQ(unzEndOfFile(unzip), 1)
-        << "end of zip not reported correctly";
+    EXPECT_EQ(unzEndOfFile(unzip), 1) << "end of zip not reported correctly";
 
-    EXPECT_EQ(err = unzCloseCurrentFile(unzip), UNZ_OK)
-        << "failed to close current file (err: " << err << ")";
+    EXPECT_EQ(err = unzCloseCurrentFile(unzip), UNZ_OK) << "failed to close current file (err: " << err << ")";
 
-    EXPECT_EQ(unztell(unzip), bytes_read)
-        << "unzip position not reported correctly";
+    EXPECT_EQ(unztell(unzip), bytes_read) << "unzip position not reported correctly";
 
     EXPECT_EQ(err = unzGoToNextFile(unzip), UNZ_OK);
     if (err != UNZ_OK)
         return;
 
     comment[0] = 0;
-    EXPECT_EQ(err = unzGetCurrentFileInfo(unzip, &file_info, filename, sizeof(filename), NULL, 0, comment, sizeof(comment)), UNZ_OK)
+    EXPECT_EQ(
+        err = unzGetCurrentFileInfo(unzip, &file_info, filename, sizeof(filename), NULL, 0, comment, sizeof(comment)),
+        UNZ_OK)
         << "failed to get current file info (err: " << err << ")";
 
     EXPECT_STREQ(comment, "test local comment");
 
-    EXPECT_EQ(err = unzGetFilePos(unzip, &file_pos), UNZ_OK)
-        << "unexpected file position (err: " << err << ")";
+    EXPECT_EQ(err = unzGetFilePos(unzip, &file_pos), UNZ_OK) << "unexpected file position (err: " << err << ")";
 
-    EXPECT_EQ(file_pos.num_of_file, 1)
-        << "invalid file position";
+    EXPECT_EQ(file_pos.num_of_file, 1) << "invalid file position";
 
-    EXPECT_GT(unzGetOffset(unzip), 0)
-        << "invalid offset";
+    EXPECT_GT(unzGetOffset(unzip), 0) << "invalid offset";
 
-    EXPECT_EQ(err = unzSeek64(unzip, 0, SEEK_SET), UNZ_OK)
-        << "cannot seek to beginning (err: " << err << ")";
+    EXPECT_EQ(err = unzSeek64(unzip, 0, SEEK_SET), UNZ_OK) << "cannot seek to beginning (err: " << err << ")";
 
     EXPECT_EQ(err = unzGoToNextFile(unzip), UNZ_END_OF_LIST_OF_FILE)
         << "failed to reach end of list of files (err: " << err << ")";
 
-    EXPECT_EQ(err = unzSeek64(unzip, 0, SEEK_SET), UNZ_PARAMERROR)
-        << "cannot seek to beginning (err: " << err << ")";
+    EXPECT_EQ(err = unzSeek64(unzip, 0, SEEK_SET), UNZ_PARAMERROR) << "cannot seek to beginning (err: " << err << ")";
 
     unzCloseCurrentFile(unzip);
 }
 
-#ifndef MZ_FILE32_API
-#  ifndef NO_FSEEKO
-#    define ftello64 ftello
-#    define fseeko64 fseeko
-#  elif defined(_MSC_VER) && (_MSC_VER >= 1400)
-#    define ftello64 _ftelli64
-#    define fseeko64 _fseeki64
+#  ifndef MZ_FILE32_API
+#    ifndef NO_FSEEKO
+#      define ftello64 ftello
+#      define fseeko64 fseeko
+#    elif defined(_MSC_VER) && (_MSC_VER >= 1400)
+#      define ftello64 _ftelli64
+#      define fseeko64 _fseeki64
+#    endif
 #  endif
-#endif
-#ifndef ftello64
-#  define ftello64 ftell
-#endif
-#ifndef fseeko64
-#  define fseeko64 fseek
-#endif
+#  ifndef ftello64
+#    define ftello64 ftell
+#  endif
+#  ifndef fseeko64
+#    define fseeko64 fseek
+#  endif
 
 static void *ZCALLBACK fopen_file_func(void *opaque, const char *filename, int mode) {
-    FILE* file = NULL;
-    const char* mode_fopen = NULL;
+    FILE *file = NULL;
+    const char *mode_fopen = NULL;
 
-    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ)
         mode_fopen = "rb";
     else if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
         mode_fopen = "r+b";
@@ -200,8 +187,7 @@ static ZPOS64_T ZCALLBACK ftell64_file_func(void *opaque, void *stream) {
 static long ZCALLBACK fseek_file_func(void *opaque, void *stream, unsigned long offset, int origin) {
     int fseek_origin = 0;
     long ret = 0;
-    switch (origin)
-    {
+    switch (origin) {
     case ZLIB_FILEFUNC_SEEK_CUR:
         fseek_origin = SEEK_CUR;
         break;
@@ -222,8 +208,7 @@ static long ZCALLBACK fseek_file_func(void *opaque, void *stream, unsigned long 
 static long ZCALLBACK fseek64_file_func(void *opaque, void *stream, ZPOS64_T offset, int origin) {
     int fseek_origin = 0;
     long ret = 0;
-    switch (origin)
-    {
+    switch (origin) {
     case ZLIB_FILEFUNC_SEEK_CUR:
         fseek_origin = SEEK_CUR;
         break;

--- a/test/test_crypt.cc
+++ b/test/test_crypt.cc
@@ -68,9 +68,9 @@ TEST(crypt, sha1) {
 }
 
 TEST(crypt, sha224) {
-#if GTEST_OS_WINDOWS
+#  if GTEST_OS_WINDOWS
     GTEST_SKIP() << "SHA224 not supported on Windows";
-#else
+#  else
     void *sha224 = nullptr;
     uint8_t hash224[MZ_HASH_SHA224_SIZE];
     char computed_hash[256];
@@ -88,13 +88,13 @@ TEST(crypt, sha224) {
     convert_buffer_to_hex_string(hash224, sizeof(hash224), computed_hash, sizeof(computed_hash));
 
     EXPECT_STREQ(computed_hash, "9e444f5f0b6582a923bd48696155f4a2f0d914e044cb64b8729a6600");
-#endif
+#  endif
 }
 
 TEST(crypt, sha256) {
-#if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
+#  if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
     GTEST_SKIP() << "SHA256 not supported on Windows XP";
-#else
+#  else
     void *sha256 = nullptr;
     uint8_t hash256[MZ_HASH_SHA256_SIZE];
     char computed_hash[256];
@@ -112,13 +112,13 @@ TEST(crypt, sha256) {
     convert_buffer_to_hex_string(hash256, sizeof(hash256), computed_hash, sizeof(computed_hash));
 
     EXPECT_STREQ(computed_hash, "7a31ea0848525f7ebfeec9ee532bcc5d6d26772427e097b86cf440a56546541c");
-#endif
+#  endif
 }
 
 TEST(crypt, sha384) {
-#if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
+#  if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
     GTEST_SKIP() << "SHA384 not supported on Windows XP";
-#else
+#  else
     void *sha384 = nullptr;
     uint8_t hash384[MZ_HASH_SHA384_SIZE];
     char computed_hash[256];
@@ -135,14 +135,15 @@ TEST(crypt, sha384) {
 
     convert_buffer_to_hex_string(hash384, sizeof(hash384), computed_hash, sizeof(computed_hash));
 
-    EXPECT_STREQ(computed_hash, "e1e42e5977965bb3621231a5df3a1e83c471fa91fde33b6a30c8c4fa0d8be29ba7171c7c9487db91e9ee7e85049f7b41");
-#endif
+    EXPECT_STREQ(computed_hash,
+                 "e1e42e5977965bb3621231a5df3a1e83c471fa91fde33b6a30c8c4fa0d8be29ba7171c7c9487db91e9ee7e85049f7b41");
+#  endif
 }
 
 TEST(crypt, sha512) {
-#if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
+#  if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
     GTEST_SKIP() << "SHA512 not supported on Windows XP";
-#else
+#  else
     void *sha512 = nullptr;
     uint8_t hash512[MZ_HASH_SHA512_SIZE];
     char computed_hash[256];
@@ -159,8 +160,10 @@ TEST(crypt, sha512) {
 
     convert_buffer_to_hex_string(hash512, sizeof(hash512), computed_hash, sizeof(computed_hash));
 
-    EXPECT_STREQ(computed_hash, "6627e7643ee7ce633e03f52d22329c3a32597364247c5275d4369985e1518626da46f595ad327667346479d246359b8b381af791ce2ac8c53a4788050eea11fe");
-#endif
+    EXPECT_STREQ(computed_hash,
+                 "6627e7643ee7ce633e03f52d22329c3a32597364247c5275d4369985e1518626da46f595ad327667346479d246359b8b381af"
+                 "791ce2ac8c53a4788050eea11fe");
+#  endif
 }
 
 TEST(crypt, aes128) {
@@ -228,15 +231,14 @@ TEST(crypt, aes128_cbc) {
     EXPECT_STREQ((char *)buf, test);
 }
 
-
 TEST(crypt, aes128_gcm) {
-#if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
+#  if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
     GTEST_SKIP() << "SHA256 not supported on Windows XP";
-#else
-    void* aes = nullptr;
-    const char* key = "awesomekeythisis";
-    const char* test = "youknowitsogrowi";
-    const char* iv = "0123456789123456";
+#  else
+    void *aes = nullptr;
+    const char *key = "awesomekeythisis";
+    const char *test = "youknowitsogrowi";
+    const char *iv = "0123456789123456";
     const char *aad = "additional authentication data";
     int32_t key_length = 0;
     int32_t test_length = 0;
@@ -250,8 +252,8 @@ TEST(crypt, aes128_gcm) {
     iv_length = (int32_t)strlen(iv);
     aad_length = (int32_t)strlen(aad);
 
-    strncpy((char*)buf, test, sizeof(buf));
-    strncpy((char*)buf + test_length, test, sizeof(buf) - test_length);
+    strncpy((char *)buf, test, sizeof(buf));
+    strncpy((char *)buf + test_length, test, sizeof(buf) - test_length);
 
     aes = mz_crypt_aes_create();
     ASSERT_NE(aes, nullptr);
@@ -261,7 +263,7 @@ TEST(crypt, aes128_gcm) {
     EXPECT_EQ(mz_crypt_aes_encrypt_final(aes, buf + test_length, test_length - 1, tag, sizeof(tag)), test_length - 1);
     mz_crypt_aes_delete(&aes);
 
-    EXPECT_STRNE((char*)buf, test);
+    EXPECT_STRNE((char *)buf, test);
 
     aes = mz_crypt_aes_create();
     ASSERT_NE(aes, nullptr);
@@ -273,7 +275,7 @@ TEST(crypt, aes128_gcm) {
 
     EXPECT_EQ(memcmp(buf, test, test_length), 0);
     EXPECT_EQ(memcmp(buf + test_length, test, test_length - 1), 0);
-#endif
+#  endif
 }
 
 TEST(crypt, aes194) {
@@ -381,9 +383,9 @@ TEST(crypt, hmac_sha1_short_password) {
 }
 
 TEST(crypt, hmac_sha256) {
-#if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
+#  if GTEST_OS_WINDOWS && _WIN32_WINNT <= _WIN32_WINNT_XP
     GTEST_SKIP() << "SHA256 not supported on Windows XP";
-#else
+#  else
     void *hmac;
     const char *key = "hm123";
     const char *test = "12345678";
@@ -401,10 +403,10 @@ TEST(crypt, hmac_sha256) {
     convert_buffer_to_hex_string(hash256, sizeof(hash256), computed_hash, sizeof(computed_hash));
 
     EXPECT_STREQ(computed_hash, "fb22a9c715a47a06bad4f6cee9badc31c921562f5d6b24adf2be009f73181f7a");
-#endif
+#  endif
 }
 
-#ifdef HAVE_WZAES
+#  ifdef HAVE_WZAES
 TEST(crypt, pbkdf2) {
     uint16_t iteration_count = 1000;
     uint8_t key[MZ_HASH_SHA1_SIZE];
@@ -412,8 +414,9 @@ TEST(crypt, pbkdf2) {
     const char *password = "passwordpasswordpasswordpassword";
     const char *salt = "8F3472E4EA57F56E36F30246DC22C173";
 
-    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password),
-        (uint8_t *)salt, (int32_t)strlen(salt), iteration_count, key, (uint16_t)sizeof(key)), MZ_OK);
+    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password), (uint8_t *)salt, (int32_t)strlen(salt),
+                              iteration_count, key, (uint16_t)sizeof(key)),
+              MZ_OK);
 
     convert_buffer_to_hex_string(key, sizeof(key), key_hex, sizeof(key_hex));
 
@@ -428,8 +431,9 @@ TEST(crypt, pbkdf2_long_odd_password) {
     const char *password = "passwordpasswordpasswordpasswordpasswordpasswordpasswordpasswordp";
     const char *salt = "8F3472E4EA57F56E36F30246DC22C173";
 
-    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password),
-        (uint8_t *)salt, (int32_t)strlen(salt), iteration_count, key, (uint16_t)sizeof(key)), MZ_OK);
+    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password), (uint8_t *)salt, (int32_t)strlen(salt),
+                              iteration_count, key, (uint16_t)sizeof(key)),
+              MZ_OK);
 
     convert_buffer_to_hex_string(key, sizeof(key), key_hex, sizeof(key_hex));
 
@@ -444,8 +448,9 @@ TEST(crypt, pbkdf2_short_password) {
     const char *password = "p";
     const char *salt = "8F3472E4EA57F56E36F30246DC22C173";
 
-    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password),
-        (uint8_t *)salt, (int32_t)strlen(salt), iteration_count, key, (uint16_t)sizeof(key)), MZ_OK);
+    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password), (uint8_t *)salt, (int32_t)strlen(salt),
+                              iteration_count, key, (uint16_t)sizeof(key)),
+              MZ_OK);
 
     convert_buffer_to_hex_string(key, sizeof(key), key_hex, sizeof(key_hex));
 
@@ -460,8 +465,9 @@ TEST(crypt, pbkdf2_rfc6070_v1) {
     const char *password = "password";
     const char *salt = "salt";
 
-    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password),
-        (uint8_t *)salt, (int32_t)strlen(salt), iteration_count, key, (uint16_t)sizeof(key)), MZ_OK);
+    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password), (uint8_t *)salt, (int32_t)strlen(salt),
+                              iteration_count, key, (uint16_t)sizeof(key)),
+              MZ_OK);
 
     convert_buffer_to_hex_string(key, sizeof(key), key_hex, sizeof(key_hex));
 
@@ -476,8 +482,9 @@ TEST(crypt, pbkdf2_rfc6070_v2) {
     const char *password = "password";
     const char *salt = "salt";
 
-    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password),
-        (uint8_t *)salt, (int32_t)strlen(salt), iteration_count, key, (uint16_t)sizeof(key)), MZ_OK);
+    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password), (uint8_t *)salt, (int32_t)strlen(salt),
+                              iteration_count, key, (uint16_t)sizeof(key)),
+              MZ_OK);
 
     convert_buffer_to_hex_string(key, sizeof(key), key_hex, sizeof(key_hex));
 
@@ -492,8 +499,9 @@ TEST(crypt, pbkdf2_rfc6070_v3) {
     const char *password = "password";
     const char *salt = "salt";
 
-    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password),
-        (uint8_t *)salt, (int32_t)strlen(salt), iteration_count, key, (uint16_t)sizeof(key)), MZ_OK);
+    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password), (uint8_t *)salt, (int32_t)strlen(salt),
+                              iteration_count, key, (uint16_t)sizeof(key)),
+              MZ_OK);
 
     convert_buffer_to_hex_string(key, sizeof(key), key_hex, sizeof(key_hex));
 
@@ -508,8 +516,9 @@ TEST(crypt, pbkdf2_rfc6070_v4) {
     const char *password = "passwordPASSWORDpassword";
     const char *salt = "saltSALTsaltSALTsaltSALTsaltSALTsalt";
 
-    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password),
-        (uint8_t *)salt, (int32_t)strlen(salt), iteration_count, key, (uint16_t)sizeof(key)), MZ_OK);
+    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, (int32_t)strlen(password), (uint8_t *)salt, (int32_t)strlen(salt),
+                              iteration_count, key, (uint16_t)sizeof(key)),
+              MZ_OK);
 
     convert_buffer_to_hex_string(key, sizeof(key), key_hex, sizeof(key_hex));
 
@@ -524,12 +533,12 @@ TEST(crypt, pbkdf2_rfc6070_v5) {
     const char *password = "pass\0word";
     const char *salt = "sa\0lt";
 
-    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, 9,
-        (uint8_t *)salt, 5, iteration_count, key, (uint16_t)sizeof(key)), MZ_OK);
+    EXPECT_EQ(mz_crypt_pbkdf2((uint8_t *)password, 9, (uint8_t *)salt, 5, iteration_count, key, (uint16_t)sizeof(key)),
+              MZ_OK);
 
     convert_buffer_to_hex_string(key, sizeof(key), key_hex, sizeof(key_hex));
 
     EXPECT_STREQ(key_hex, "56fa6aa75548099dcc37d7f03425e0c3");
 }
-#endif
+#  endif
 #endif

--- a/test/test_file.cc
+++ b/test/test_file.cc
@@ -19,7 +19,7 @@ TEST(os, get_file_date_ads) {
     const std::string main_stream_name = "minizip_ads_test";
     const std::string ads_name = main_stream_name + ":ads";
     const std::string ads_contents = "Alternate Data Stream";
-  
+
     // Create main stream
     std::ofstream main_stream(main_stream_name);
     main_stream.close();

--- a/test/test_path.cc
+++ b/test/test_path.cc
@@ -23,31 +23,29 @@ struct resolve_path_param {
 };
 
 constexpr resolve_path_param resolve_path_tests[] = {
-    { "c:\\test\\.", "c:\\test\\" },
-    { "c:\\test\\.\\", "c:\\test\\" },
-    { "c:\\test\\.\\.", "c:\\test\\" },
-    { "c:\\test\\..", "c:\\" },
-    { "c:\\test\\..\\", "c:\\" },
-    { "c:\\test\\.\\..", "c:\\" },
-    { "c:\\test\\.\\\\..", "c:\\" },
-    { ".", "." },
-    { ".\\", "" },
-    { "..", "" },
-    { "..\\", "" },
-    { ".\\test\\123", "test\\123" },
-    { ".\\..\\test\\123", "test\\123" },
-    { "..\\..\\test\\123", "test\\123" },
-    { "test\\.abc.txt", "test\\.abc.txt" },
-    { "c:\\test\\123\\.\\abc.txt", "c:\\test\\123\\abc.txt" },
-    { "c:\\test\\123\\..\\abc.txt", "c:\\test\\abc.txt" },
-    { "c:\\test\\123\\..\\..\\abc.txt", "c:\\abc.txt" },
-    { "c:\\test\\123\\..\\..\\..\\abc.txt", "abc.txt" },
-    { "c:\\test\\123\\..\\.\\..\\abc.txt", "c:\\abc.txt" },
+    {                       "c:\\test\\.",             "c:\\test\\"},
+    {                     "c:\\test\\.\\",             "c:\\test\\"},
+    {                    "c:\\test\\.\\.",             "c:\\test\\"},
+    {                      "c:\\test\\..",                   "c:\\"},
+    {                    "c:\\test\\..\\",                   "c:\\"},
+    {                   "c:\\test\\.\\..",                   "c:\\"},
+    {                 "c:\\test\\.\\\\..",                   "c:\\"},
+    {                                 ".",                      "."},
+    {                               ".\\",                       ""},
+    {                                "..",                       ""},
+    {                              "..\\",                       ""},
+    {                      ".\\test\\123",              "test\\123"},
+    {                  ".\\..\\test\\123",              "test\\123"},
+    {                 "..\\..\\test\\123",              "test\\123"},
+    {                    "test\\.abc.txt",         "test\\.abc.txt"},
+    {         "c:\\test\\123\\.\\abc.txt", "c:\\test\\123\\abc.txt"},
+    {        "c:\\test\\123\\..\\abc.txt",      "c:\\test\\abc.txt"},
+    {    "c:\\test\\123\\..\\..\\abc.txt",            "c:\\abc.txt"},
+    {"c:\\test\\123\\..\\..\\..\\abc.txt",                "abc.txt"},
+    { "c:\\test\\123\\..\\.\\..\\abc.txt",            "c:\\abc.txt"},
 };
 
-class path_resolve : public ::testing::TestWithParam<resolve_path_param> {
-
-};
+class path_resolve : public ::testing::TestWithParam<resolve_path_param> {};
 
 INSTANTIATE_TEST_SUITE_P(os, path_resolve, testing::ValuesIn(resolve_path_tests));
 

--- a/test/test_stream.cc
+++ b/test/test_stream.cc
@@ -15,10 +15,10 @@
 #include <gtest/gtest.h>
 
 typedef void (*stream_test_cb)(const char *name, int32_t count, const uint8_t *find, int32_t find_size,
-    mz_stream_find_cb find_cb);
+                               mz_stream_find_cb find_cb);
 
 static void test_stream_find_begin(const char *name, int32_t count, const uint8_t *find, int32_t find_size,
-    mz_stream_find_cb find_cb) {
+                                   mz_stream_find_cb find_cb) {
     void *mem_stream = NULL;
     int32_t i = 0;
     int32_t x = 0;
@@ -49,10 +49,9 @@ static void test_stream_find_begin(const char *name, int32_t count, const uint8_
 
         /* Should always find at the start of the stream if entire needle
            was written to stream */
-        EXPECT_EQ(position, (i < find_size) ? -1 : 0)
-            << "name: " << name << std::endl
-            << "find_size: " << find_size << std::endl
-            << "index: " << i << std::endl;
+        EXPECT_EQ(position, (i < find_size) ? -1 : 0) << "name: " << name << std::endl
+                                                      << "find_size: " << find_size << std::endl
+                                                      << "index: " << i << std::endl;
 
         mz_stream_seek(mem_stream, 0, MZ_SEEK_END);
         last_pos = mz_stream_tell(mem_stream);
@@ -64,7 +63,7 @@ static void test_stream_find_begin(const char *name, int32_t count, const uint8_
 }
 
 static void test_stream_find_end(const char *name, int32_t count, const uint8_t *find, int32_t find_size,
-    mz_stream_find_cb find_cb) {
+                                 mz_stream_find_cb find_cb) {
     void *mem_stream = NULL;
     int32_t i = 0;
     int32_t x = 0;
@@ -96,10 +95,9 @@ static void test_stream_find_end(const char *name, int32_t count, const uint8_t 
 
         /* Should always find after zeros if entire needle
            was written to stream */
-        EXPECT_EQ(position, (i < find_size) ? -1 : (i - find_size))
-            << "name: " << name << std::endl
-            << "find_size: " << find_size << std::endl
-            << "index: " << i << std::endl;
+        EXPECT_EQ(position, (i < find_size) ? -1 : (i - find_size)) << "name: " << name << std::endl
+                                                                    << "find_size: " << find_size << std::endl
+                                                                    << "index: " << i << std::endl;
 
         mz_stream_seek(mem_stream, 0, MZ_SEEK_END);
         last_pos = mz_stream_tell(mem_stream);
@@ -111,7 +109,7 @@ static void test_stream_find_end(const char *name, int32_t count, const uint8_t 
 }
 
 static void test_stream_find_middle(const char *name, int32_t count, const uint8_t *find, int32_t find_size,
-    mz_stream_find_cb find_cb) {
+                                    mz_stream_find_cb find_cb) {
     void *mem_stream = NULL;
     int32_t i = 0;
     int32_t x = 0;
@@ -139,13 +137,12 @@ static void test_stream_find_middle(const char *name, int32_t count, const uint8
         if (find_cb == mz_stream_find)
             mz_stream_seek(mem_stream, 0, MZ_SEEK_SET);
 
-        find_cb(mem_stream, (const void *)find, find_size, i + find_size+ i, &position);
+        find_cb(mem_stream, (const void *)find, find_size, i + find_size + i, &position);
 
         /* Should always find after initial set of zeros */
-        EXPECT_EQ(position, i)
-            << "name: " << name << std::endl
-            << "find_size: " << find_size << std::endl
-            << "index: " << i << std::endl;
+        EXPECT_EQ(position, i) << "name: " << name << std::endl
+                               << "find_size: " << find_size << std::endl
+                               << "index: " << i << std::endl;
 
         mz_stream_seek(mem_stream, 0, MZ_SEEK_END);
         last_pos = mz_stream_tell(mem_stream);
@@ -157,7 +154,7 @@ static void test_stream_find_middle(const char *name, int32_t count, const uint8
 }
 
 static void test_stream_find_middle_odd(const char *name, int32_t count, const uint8_t *find, int32_t find_size,
-    mz_stream_find_cb find_cb) {
+                                        mz_stream_find_cb find_cb) {
     void *mem_stream = NULL;
     int32_t i = 0;
     int32_t x = 0;
@@ -188,10 +185,9 @@ static void test_stream_find_middle_odd(const char *name, int32_t count, const u
         find_cb(mem_stream, (const void *)find, find_size, i + find_size + i + 1, &position);
 
         /* Should always find after initial set of zeros */
-        EXPECT_EQ(position, i)
-            << "name: " << name << std::endl
-            << "find_size: " << find_size << std::endl
-            << "index: " << i << std::endl;
+        EXPECT_EQ(position, i) << "name: " << name << std::endl
+                               << "find_size: " << find_size << std::endl
+                               << "index: " << i << std::endl;
 
         mz_stream_seek(mem_stream, 0, MZ_SEEK_END);
         last_pos = mz_stream_tell(mem_stream);
@@ -203,8 +199,8 @@ static void test_stream_find_middle_odd(const char *name, int32_t count, const u
 }
 
 struct stream_find_param {
-    const char        *name;
-    stream_test_cb    test_cb;
+    const char *name;
+    stream_test_cb test_cb;
     mz_stream_find_cb find_cb;
 
     friend std::ostream &operator<<(std::ostream &os, const stream_find_param &param) {
@@ -213,19 +209,17 @@ struct stream_find_param {
 };
 
 constexpr stream_find_param find_tests[] = {
-    { "begin", test_stream_find_begin, mz_stream_find },
-    { "begin reverse", test_stream_find_begin, mz_stream_find_reverse },
-    { "end", test_stream_find_end, mz_stream_find },
-    { "end reverse", test_stream_find_end, mz_stream_find_reverse },
-    { "middle", test_stream_find_middle, mz_stream_find },
-    { "middle reverse", test_stream_find_middle, mz_stream_find_reverse },
-    { "middle odd", test_stream_find_middle_odd, mz_stream_find },
-    { "middle odd reverse", test_stream_find_middle_odd, mz_stream_find_reverse }
+    {             "begin",      test_stream_find_begin,         mz_stream_find},
+    {     "begin reverse",      test_stream_find_begin, mz_stream_find_reverse},
+    {               "end",        test_stream_find_end,         mz_stream_find},
+    {       "end reverse",        test_stream_find_end, mz_stream_find_reverse},
+    {            "middle",     test_stream_find_middle,         mz_stream_find},
+    {    "middle reverse",     test_stream_find_middle, mz_stream_find_reverse},
+    {        "middle odd", test_stream_find_middle_odd,         mz_stream_find},
+    {"middle odd reverse", test_stream_find_middle_odd, mz_stream_find_reverse}
 };
 
-class stream_find : public ::testing::TestWithParam<stream_find_param> {
-
-};
+class stream_find : public ::testing::TestWithParam<stream_find_param> {};
 
 INSTANTIATE_TEST_SUITE_P(stream, stream_find, testing::ValuesIn(find_tests));
 


### PR DESCRIPTION
483950d09dad0c9f845c22112e2ffde81e0af951 introduced .clang-format which however is not respected in current v4.0.8 (55db144e03027b43263e5ebcb599bf0878ba58de). Hence, contributions via PR might get somehow noisy as this one shows.