### PR TITLE
Align structures for 64-bit platforms

### DIFF
--- a/minizip.c
+++ b/minizip.c
@@ -23,16 +23,16 @@
 /***************************************************************************/
 
 typedef struct minizip_opt_s {
+    int64_t disk_size;
+    int32_t encoding;
     uint8_t include_path;
     int16_t compress_level;
     uint8_t compress_method;
     uint8_t overwrite;
     uint8_t append;
-    int64_t disk_size;
     uint8_t follow_links;
     uint8_t store_links;
     uint8_t zip_cd;
-    int32_t encoding;
     uint8_t verbose;
     uint8_t aes;
 } minizip_opt;

--- a/mz_crypt_openssl.c
+++ b/mz_crypt_openssl.c
@@ -64,8 +64,8 @@ typedef struct mz_crypt_sha_s {
 #else
     EVP_MD_CTX *ctx;
 #endif
-    int32_t initialized;
     unsigned long error;
+    int32_t initialized;
     uint16_t algorithm;
 } mz_crypt_sha;
 
@@ -491,8 +491,8 @@ typedef struct mz_crypt_hmac_s {
     EVP_MAC *mac;
     EVP_MAC_CTX *ctx;
 #endif
-    int32_t initialized;
     unsigned long error;
+    int32_t initialized;
     uint16_t algorithm;
 } mz_crypt_hmac;
 

--- a/mz_strm_split.c
+++ b/mz_strm_split.c
@@ -35,19 +35,19 @@ static mz_stream_vtbl mz_stream_split_vtbl = {
 
 typedef struct mz_stream_split_s {
     mz_stream stream;
-    int32_t is_open;
     int64_t disk_size;
     int64_t total_in;
     int64_t total_in_disk;
     int64_t total_out;
     int64_t total_out_disk;
+    int32_t is_open;
     int32_t mode;
     char *path_cd;
     char *path_disk;
     uint32_t path_disk_size;
     int32_t number_disk;
-    int32_t current_disk;
     int64_t current_disk_size;
+    int32_t current_disk;
     int32_t reached_end;
 } mz_stream_split;
 


### PR DESCRIPTION
Fully similar issue as in zlib-ng: https://github.com/zlib-ng/zlib-ng/pull/1881

- mz_stream_split 120 -> 104 bytes
- mz_zip_file, mz_zip_entry 128 -> 120 bytes
- minizip_opt 32 -> 24 bytes
- mz_crypt_sha 32 -> 24 bytes
- mz_crypt_hmac 40 -> 32 bytes