### PR TITLE
Same CMake Build zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,10 @@ if(MZ_ZLIB)
 
         set(PC_PRIVATE_DEPS "zlib-ng")
         set(ZLIB_COMPAT OFF)
+    elseif(TARGET zlib)
+        message(STATUS "Using TARGET zlib")
+        set(PC_PRIVATE_DEPS "zlib")
+        list(APPEND MINIZIP_LIB zlib)
     elseif(ZLIB_FOUND AND NOT MZ_FORCE_FETCH_LIBS)
         message(STATUS "Using ZLIB ${ZLIB_VERSION}")
 


### PR DESCRIPTION
I wanted to build zlib-ng within the same project, but I don't want to make a build-install step for that. The fetch function also did not work. So here I propose to use an existing zlib target, found in the current cmake project