### PR TITLE
crypt.h: Remove register keyword

### DIFF
--- a/compat/crypt.h
+++ b/compat/crypt.h
@@ -59,7 +59,7 @@ static int update_keys(unsigned long *pkeys, const z_crc_t *pcrc_32_tab, int c) 
     (*(pkeys + 1)) += (*(pkeys + 0)) & 0xff;
     (*(pkeys + 1)) = (*(pkeys + 1)) * 134775813L + 1;
     {
-        register int keyshift = (int)((*(pkeys + 1)) >> 24);
+        int keyshift = (int)((*(pkeys + 1)) >> 24);
         (*(pkeys + 2)) = CRC32((*(pkeys + 2)), keyshift);
     }
     return c;


### PR DESCRIPTION
Fixes:
 | In file included from /buildarea/tmp/work/core2-64-poky-linux/minizip-ng/4.0.8/git/test/test_compat.cc:17:
 | /buildarea/tmp/work/core2-64-poky-linux/minizip-ng/4.0.8/git/compat/crypt.h:62:9: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
 |    62 |         register int keyshift = (int)((*(pkeys + 1)) >> 24);
 |       |         ^~~~~~~~
 | 1 error generated.