### PR TITLE
gitgnore build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# builds
+_deps/
 build/
+CMakeFiles/
+lib/
+Testing/
 third_party/
+
+# IDE
 .vscode


### PR DESCRIPTION
When I run those commands, I get a lot of folders created:
```
cmake -S . -B . -D MZ_BUILD_TESTS=ON -D MZ_BUILD_UNIT_TESTS=ON -D BUILD_SHARED_LIBS=OFF -D CMAKE_BUILD_TYPE=Debug
cmake --build . --config Debug
ctest --output-on-failure -C Debug
```

So I'm adding those folders to .gitignore.