### PR TITLE
updating github actions for ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu 20 GCC
-            os: ubuntu-20.04
+        # available images: https://github.com/actions/runner-images
+          - name: Ubuntu 22 GCC
+            os: ubuntu-22.04
             compiler: gcc
             cxx-compiler: g++
 
@@ -38,19 +39,19 @@ jobs:
             codecov: ubuntu_gcc_msan
 
           # No code coverage on release builds
-          - name: Ubuntu 20 Clang
-            os: ubuntu-20.04
+          - name: Ubuntu 22 Clang
+            os: ubuntu-22.04
             compiler: clang
             cxx-compiler: clang++
             deploy: true
             deploy-name: linux
 
-          - name: Ubuntu 20 Clang 6.0
-            os: ubuntu-20.04
-            compiler: clang-6.0
-            cxx-compiler: clang++-6.0
-            version: "6.0"
-            packages: llvm-6.0 clang-6.0
+          - name: Ubuntu 22 Clang 11
+            os: ubuntu-22.04
+            compiler: clang-11
+            cxx-compiler: clang++-11
+            version: "11"
+            packages: llvm-11 clang-11
 
           - name: Ubuntu GCC
             os: ubuntu-latest


### PR DESCRIPTION
The minimum supported ubuntu is now 22.04: https://github.com/actions/runner-images
The minimum supported clang is now 13: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md

[edit]
I was able to downgrade to clang 11, but not clang 10.