### PR TITLE
Support any character encoding

### DIFF
--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -53,21 +53,17 @@ char *mz_os_utf8_string_create(const char *string, int32_t encoding) {
     char *string_utf8 = NULL;
     char *string_utf8_ptr = NULL;
 
-    if (!string)
+    if (!string || encoding <= 0)
         return NULL;
 
-    if (encoding == MZ_ENCODING_CODEPAGE_437)
-        from_encoding = "CP437";
-    else if (encoding == MZ_ENCODING_CODEPAGE_932)
-        from_encoding = "CP932";
-    else if (encoding == MZ_ENCODING_CODEPAGE_936)
-        from_encoding = "CP936";
-    else if (encoding == MZ_ENCODING_CODEPAGE_950)
-        from_encoding = "CP950";
-    else if (encoding == MZ_ENCODING_UTF8)
+    if (encoding == MZ_ENCODING_UTF8)
         from_encoding = "UTF-8";
-    else
-        return NULL;
+    else {
+        /// up to CP2147483647
+        char string_encoding[13];
+        snprintf(string_encoding, sizeof(string_encoding), "CP%03" PRId32, encoding);
+        from_encoding = string_encoding;
+    }
 
     cd = iconv_open("UTF-8", from_encoding);
     if (cd == (iconv_t)-1)


### PR DESCRIPTION
The existing list of supported encodings was added by ea5e45dfe2c42ade58e260cb14b910f75b385525.
That list was quite limited.
In a more practical way, this PR supports any encoding that iconv supports:
```
➜  iconv --list | grep " [0-9]\+ "
CP037 037 EBCDIC-CP-CA EBCDIC-CP-NL EBCDIC-CP-US EBCDIC-CP-WT IBM037
CP038 038 EBCDIC-INT IBM038
CP10000 10000 CP10000_MACROMAN
CP10006 10006 CP10006_MACGREEK
CP10007 10007 CP10007_MACCYRILLIC MS-MAC-CYRILLIC
CP10029 10029 CP10029_MACLATIN2
CP1006 1006 MSCP1006
CP10079 10079 CP10079_MACICELANDIC
CP10081 10081 CP10081_MACTURKISH
CP1026 1026 IBM1026
CP1046 1046 IBM1046
CP1124 1124 IBM1124
CP1125 1125 IBM1125
CP1129 1129 IBM1129
CP1131 1131 IBM1131
CP1133 1133 IBM-CP1133 IBM1133
CP1161 1161 CSIBM1161 IBM-1161 IBM1161
CP1162 1162 CSIBM1162 IBM-1162 IBM1162 MSCP874 WINDOWS-874
CP1163 1163 CSIBM1163 IBM-1163 IBM1163
CP1250 1250 MS-EE MSCP1250 WINDOWS-1250
CP1251 1251 MS-CYRL MSCP1251 WINDOWS-1251
CP1252 1252 MS-ANSI MSCP1252 WINDOWS-1252
CP1253 1253 MS-GREEK MSCP1253 WINDOWS-1253
CP1254 1254 MS-TURK MSCP1254 WINDOWS-1254
CP1255 1255 MS-HEBR MSCP1255 WINDOWS-1255
CP1256 1256 MS-ARAB MSCP1256 WINDOWS-1256
CP1257 1257 MSCP1257 WINBALTRIM WINDOWS-1257
CP1258 1258 MSCP1258 WINDOWS-1258
CP273 273 IBM273
CP274 274 EBCDIC-BE IBM274
CP275 275 EBCDIC-BR IBM275
CP277 277 EBCDIC-CP-DK EBCDIC-CP-NO IBM277
CP278 278 EBCDIC-CP-FI EBCDIC-CP-SE IBM278
CP280 280 EBCDIC-CP-IT IBM280
CP281 281 EBCDIC-JP-E IBM281
CP284 284 EBCDIC-CP-ES IBM284
CP285 285 EBCDIC-CP-GB IBM285
CP290 290 EBCDIC-JP-KANA IBM290
CP297 297 EBCDIC-CP-FR IBM297
CP420 420 EBCDIC-CP-AR1 IBM420
CP423 423 EBCDIC-CP-GR IBM423
CP424 424 EBCDIC-CP-HE IBM424
CP437 437 CSPC8CODEPAGE437 IBM437
CP500 500 EBCDIC-CP-BE EBCDIC-CP-CH IBM500
CP50220 50220 MSCP50220 WINDOWS-50220
CP50221 50221 MSCP50221 WINDOWS-50221
CP50222 50222 MSCP50222 WINDOWS-50222
CP51932 51932 MS51932 MSCP51932 WINDOWS-51932
CP737 737 MSCP737
CP775 775 CSPC775BALTIC IBM775 MSCP775
CP850 850 CSPC850MULTILINGUAL IBM850
CP851 851 IBM851
CP852 852 CSPC852 CSPCP852 IBM852
CP853 853 IBM853
CP855 855 CSIBM855 IBM855
CP856 856 MSCP856
CP857 857 CSIBM857 IBM857
CP858 858 IBM858
CP860 860 CSIBM860 IBM860
CP861 861 CP-IS CSIBM861 IBM861
CP862 862 CSPC862LATINHEBREW IBM862
CP863 863 CSIBM863 IBM863
CP864 864 CSIBM864 IBM864
CP865 865 CSIBM865 IBM865
CP866 866 CSIBM866 IBM866 MSCP866
CP868 868 CP-AR IBM868
CP869 869 CP-GR CSIBM869 IBM869
CP870 870 EBCDIC-CP-ROECE EBCDIC-CP-YU IBM870
CP871 871 EBCDIC-CP-IS IBM871
CP874 874 IBM874 WINDOWS-874
CP875 875 MSCP875
CP880 880 EBCDIC-CYRILLIC IBM880
CP891 891 IBM891
CP903 903 IBM903
CP904 904 IBM904
CP905 905 EBCDIC-CP-TR IBM905
CP918 918 EBCDIC-CP-AR2 IBM918
CP922 922 IBM922
CP932 932 CSWINDOWS31J MS932 MSCP932 SHIFT_JIS-MS SJIS-MS SJIS-OPEN SJIS-WIN WINDOWS-31J WINDOWS-932
CP936 936 MS936 MSCP936 WINDOWS-936
CP942 942 IBM942 942C CP942C IBM942C
CP943 943 IBM943 943C CP943C IBM943C
CP949 949 MSCP949 UHC
CP950 950 MSCP950
ISO646-US 646 ANSI_X3.4-1968 ANSI_X3.4-1986 ASCII CP367 CSASCII IBM367 ISO-IR-6 ISO_646.IRV:1991 US US-ASCII
```