### PR TITLE
Fix zlib-ng detection and installation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,9 +195,7 @@ if(MZ_ZLIB)
     if(ZLIB-NG_FOUND AND NOT MZ_FORCE_FETCH_LIBS)
         message(STATUS "Using ZLIB-NG")
 
-        list(APPEND MINIZIP_INC ${ZLIB-NG_INCLUDE_DIRS})
-        list(APPEND MINIZIP_LIB ${ZLIB-NG_LIBRARIES})
-        list(APPEND MINIZIP_LBD ${ZLIB-NG_LIBRARY_DIRS})
+        list(APPEND MINIZIP_LIB zlib-ng::zlib)
 
         set(PC_PRIVATE_DEPS "zlib-ng")
         set(ZLIB_COMPAT OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ if(MZ_ZLIB)
     # Check if zlib is present
     if(NOT MZ_FORCE_FETCH_LIBS)
         if (MZ_ZLIB_FLAVOR STREQUAL "zlib-ng" OR MZ_ZLIB_FLAVOR STREQUAL "auto")
-            find_package(ZLIB-NG QUIET)
+            find_package(ZLIB-NG QUIET CONFIG)
         endif()
         if (MZ_ZLIB_FLAVOR STREQUAL "zlib" OR MZ_ZLIB_FLAVOR STREQUAL "auto")
             find_package(ZLIB QUIET)
@@ -215,8 +215,7 @@ if(MZ_ZLIB)
 
         clone_repo(zlib https://github.com/zlib-ng/zlib-ng stable)
 
-        # Don't automatically add all targets to the solution
-        add_subdirectory(${ZLIB_SOURCE_DIR} ${ZLIB_BINARY_DIR} EXCLUDE_FROM_ALL)
+        add_subdirectory(${ZLIB_SOURCE_DIR} ${ZLIB_BINARY_DIR})
 
         list(APPEND MINIZIP_INC ${ZLIB_SOURCE_DIR})
         list(APPEND MINIZIP_INC ${ZLIB_BINARY_DIR})


### PR DESCRIPTION
Following on from https://github.com/zlib-ng/minizip-ng/pull/886 this fixes the following issues

1.
```cmake
add_subdirectory(${ZLIB_SOURCE_DIR} ${ZLIB_BINARY_DIR} EXCLUDE_FROM_ALL)
```
The `EXCLUDE_FROM_ALL` here will prevent the install steps for zlib-ng from being run, so unless the consumer explicitly installs their own zlib-ng package first, `zlib-ng-config.cmake` will not be installed and so the eventual call to `find_package(minizip REQUIRED CONFIG)` will fail.

2.

Even if zlib-ng is installed externally first, the minizip-ng configuration will fall into the `MZ_FETCH_LIBS` branch and clone zlib-ng from github anyway, because the presence of zlib-ng is checked with `find_package(ZLIB-NG QUIET)` instead of `find_package(ZLIB-NG QUIET CONFIG)`

3.

When zlib-ng is located via `find_package()` the following commands don't work and so minizip-ng will not build:
```cmake
        list(APPEND MINIZIP_INC ${ZLIB-NG_INCLUDE_DIRS})
        list(APPEND MINIZIP_LIB ${ZLIB-NG_LIBRARIES})
        list(APPEND MINIZIP_LBD ${ZLIB-NG_LIBRARY_DIRS})
```
They can be replaced with simply:
```cmake
list(APPEND MINIZIP_LIB zlib-ng::zlib)
```
which fixes the build.