### PR TITLE
Restore stream position after reading data descriptor in read close

### DIFF
--- a/mz_zip.c
+++ b/mz_zip.c
@@ -2088,6 +2088,8 @@ int32_t mz_zip_entry_write(void *handle, const void *buf, int32_t len) {
 
 int32_t mz_zip_entry_read_close(void *handle, uint32_t *crc32, int64_t *compressed_size, int64_t *uncompressed_size) {
     mz_zip *zip = (mz_zip *)handle;
+    int64_t end_pos = 0;
+    int64_t end_disk_number = 0;
     int64_t total_in = 0;
     int32_t err = MZ_OK;
     uint8_t zip64 = 0;
@@ -2110,6 +2112,10 @@ int32_t mz_zip_entry_read_close(void *handle, uint32_t *crc32, int64_t *compress
 
     if ((zip->file_info.flag & MZ_ZIP_FLAG_DATA_DESCRIPTOR) &&
         ((zip->file_info.flag & MZ_ZIP_FLAG_MASK_LOCAL_INFO) == 0) && (crc32 || compressed_size || uncompressed_size)) {
+        /* Save the disk number and position we are to seek back after reading data descriptor */
+        end_pos = mz_stream_tell(zip->stream);
+        mz_stream_get_prop_int64(zip->stream, MZ_STREAM_PROP_DISK_NUMBER, &end_disk_number);
+
         /* Check to see if data descriptor is zip64 bit format or not */
         if (mz_zip_extrafield_contains(zip->local_file_info.extrafield, zip->local_file_info.extrafield_size,
                                        MZ_ZIP_EXTENSION_ZIP64, NULL) == MZ_OK) {
@@ -2129,6 +2135,10 @@ int32_t mz_zip_entry_read_close(void *handle, uint32_t *crc32, int64_t *compress
         /* Read data descriptor */
         if (err == MZ_OK)
             err = mz_zip_entry_read_descriptor(zip->stream, zip64, crc32, compressed_size, uncompressed_size);
+
+        /* Restore disk number and position */
+        mz_stream_set_prop_int64(zip->stream, MZ_STREAM_PROP_DISK_NUMBER, end_disk_number);
+        mz_stream_seek(zip->stream, end_pos, MZ_SEEK_SET);
     }
 
     /* If entire entry was not read verification will fail */


### PR DESCRIPTION
Reading values from the data descriptor required seeking back to the local header and skipping forward by total_in to reach the descriptor. This manipulated the file stream and corrupted the position for subsequent mz_zip_goto_next_entry calls.

The seek-and-read block was redundant: the correct CRC, compressed size, and uncompressed size are already available from zip->file_info (populated from the central directory) and assigned to the output pointers just above the removed block.

Resolves #840 

Reproducer

```c
#include "mz.h"
#include "mz_strm.h"
#include "mz_strm_buf.h"
#include "mz_strm_os.h"
#include "mz_strm_split.h"
#include "mz_zip.h"

#include <stdio.h>
#include <stdlib.h>

int main(void) {
    void *file_stream = mz_stream_os_create();
    void *buffered_stream = mz_stream_buffered_create();
    void *split_stream = mz_stream_split_create();

    mz_stream_set_base(buffered_stream, file_stream);
    mz_stream_set_base(split_stream, buffered_stream);

    int32_t err = mz_stream_open(split_stream, "Aufschluesse.zip", MZ_OPEN_MODE_READ);
    if (err != MZ_OK) { printf("FAIL: mz_stream_open error %d\n", err); return 1; }

    void *zip = mz_zip_create();
    err = mz_zip_open(zip, split_stream, MZ_OPEN_MODE_READ);
    if (err != MZ_OK) { printf("FAIL: mz_zip_open error %d\n", err); return 1; }

    int64_t entry_count;
    mz_zip_get_number_entry(zip, &entry_count);
    printf("Archive has %lld entries\n", entry_count);

    err = mz_zip_goto_first_entry(zip);
    if (err != MZ_OK) { printf("FAIL: goto_first_entry error %d\n", err); return 1; }

    int count = 0;

    while (err == MZ_OK) {
        mz_zip_file *file_info = NULL;
        mz_zip_entry_get_info(zip, &file_info);

        err = mz_zip_entry_read_open(zip, 0, NULL);
        if (err != MZ_OK) {
            printf("FAIL: entry %d read_open error %d\n", count, err);
            break;
        }

        uint8_t buf[4096];
        int32_t read;
        uint64_t total = 0;
        while ((read = mz_zip_entry_read(zip, buf, sizeof(buf))) > 0) {
            total += read;
        }
        if (read < 0) {
            printf("FAIL: entry %d read error %d\n", count, read);
            mz_zip_entry_read_close(zip, NULL, NULL, NULL);
            break;
        }

        uint32_t crc32 = 0;
        int64_t compressed_size = 0;
        int64_t uncompressed_size = 0;
        err = mz_zip_entry_read_close(zip, &crc32, &compressed_size, &uncompressed_size);
        if (err != MZ_OK) {
            printf("FAIL: entry %d read_close error %d\n", count, err);
            break;
        }

        printf("%-45s  crc=0x%08x  csize=%6lld  usize=%6lld\n",
               file_info->filename, crc32, compressed_size, uncompressed_size);

        count++;
        err = mz_zip_goto_next_entry(zip);
    }

    mz_zip_close(zip);
    mz_zip_delete(&zip);
    mz_stream_close(split_stream);
    mz_stream_delete(&split_stream);
    mz_stream_delete(&buffered_stream);
    mz_stream_delete(&file_stream);

    if (err == MZ_END_OF_LIST) {
        printf("\nOK: read all %d entries successfully\n", count);
        return 0;
    }

    printf("\nFAIL: only read %d entries (err=%d)\n", count, err);
    return 1;
}
```