### PR TITLE
Add MZ_EXPORT to public API symbols and hide internal symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -715,7 +715,8 @@ set_target_properties(${MINIZIP_TARGET} PROPERTIES
                       VERSION ${VERSION}
                       SOVERSION ${SOVERSION}
                       LINKER_LANGUAGE C
-                      DEFINE_SYMBOL "MZ_EXPORTS")
+                      DEFINE_SYMBOL "MZ_EXPORTS"
+                      C_VISIBILITY_PRESET hidden)
 
 if(MINIZIP_LFG)
     target_link_options(${MINIZIP_TARGET} PRIVATE ${MINIZIP_LFG})

--- a/compat/ioapi.h
+++ b/compat/ioapi.h
@@ -7,7 +7,15 @@
 typedef uint64_t ZPOS64_T;
 
 #ifndef ZEXPORT
-#  define ZEXPORT
+#  if defined(MZ_EXPORTS)
+#    if defined(_WIN32)
+#      define ZEXPORT __declspec(dllexport)
+#    else
+#      define ZEXPORT __attribute__((visibility("default")))
+#    endif
+#  else
+#    define ZEXPORT
+#  endif
 #endif
 
 #ifdef __cplusplus
@@ -82,11 +90,11 @@ ZEXPORT void fill_memory_filefunc(zlib_filefunc_def *pzlib_filefunc_def);
 
 /***************************************************************************/
 
-int32_t mz_stream_ioapi_set_filefunc(void *stream, zlib_filefunc_def *filefunc);
-int32_t mz_stream_ioapi_set_filefunc64(void *stream, zlib_filefunc64_def *filefunc);
+ZEXPORT int32_t mz_stream_ioapi_set_filefunc(void *stream, zlib_filefunc_def *filefunc);
+ZEXPORT int32_t mz_stream_ioapi_set_filefunc64(void *stream, zlib_filefunc64_def *filefunc);
 
-void *mz_stream_ioapi_create(void);
-void mz_stream_ioapi_delete(void **stream);
+ZEXPORT void *mz_stream_ioapi_create(void);
+ZEXPORT void mz_stream_ioapi_delete(void **stream);
 
 /***************************************************************************/
 

--- a/compat/unzip.h
+++ b/compat/unzip.h
@@ -190,7 +190,7 @@ ZEXPORT int unzLocateFile(unzFile file, const char *filename, unzFileNameCompare
 ZEXPORT int unzGetLocalExtrafield(unzFile file, void *buf, unsigned int len);
 
 /* Compatibility layer with older minizip-ng (mz_unzip.h). */
-unzFile unzOpen_MZ(void *stream);
+ZEXPORT unzFile unzOpen_MZ(void *stream);
 ZEXPORT int unzClose_MZ(unzFile file);
 ZEXPORT void *unzGetHandle_MZ(unzFile file);
 ZEXPORT void *unzGetStream_MZ(unzFile file);

--- a/compat/zip.h
+++ b/compat/zip.h
@@ -170,8 +170,8 @@ ZEXPORT int zipOpenNewFileInZip5(zipFile file, const char *filename, const zip_f
 ZEXPORT int zipCloseFileInZip64(zipFile file);
 ZEXPORT int zipClose_64(zipFile file, const char *global_comment);
 ZEXPORT int zipClose2_64(zipFile file, const char *global_comment, uint16_t version_madeby);
-int zipClose_MZ(zipFile file, const char *global_comment);
-int zipClose2_MZ(zipFile file, const char *global_comment, uint16_t version_madeby);
+ZEXPORT int zipClose_MZ(zipFile file, const char *global_comment);
+ZEXPORT int zipClose2_MZ(zipFile file, const char *global_comment, uint16_t version_madeby);
 
 #ifdef __cplusplus
 }

--- a/mz.h
+++ b/mz.h
@@ -148,8 +148,12 @@
 /* MZ_UTILITY */
 #define MZ_UNUSED(SYMBOL) ((void)SYMBOL)
 
-#if defined(_WIN32) && defined(MZ_EXPORTS)
-#  define MZ_EXPORT __declspec(dllexport)
+#if defined(MZ_EXPORTS)
+#  if defined(_WIN32)
+#    define MZ_EXPORT __declspec(dllexport)
+#  else
+#    define MZ_EXPORT __attribute__((visibility("default")))
+#  endif
 #else
 #  define MZ_EXPORT
 #endif

--- a/mz_crypt.h
+++ b/mz_crypt.h
@@ -16,45 +16,40 @@ extern "C" {
 #endif
 
 /***************************************************************************/
-
-uint32_t mz_crypt_crc32_update(uint32_t value, const uint8_t *buf, int32_t size);
-
-int32_t mz_crypt_pbkdf2(const uint8_t *password, int32_t password_length, const uint8_t *salt, int32_t salt_length,
-                        uint32_t iteration_count, uint8_t *key, uint16_t key_length);
+MZ_EXPORT uint32_t mz_crypt_crc32_update(uint32_t value, const uint8_t *buf, int32_t size);
+MZ_EXPORT int32_t mz_crypt_pbkdf2(const uint8_t *password, int32_t password_length, const uint8_t *salt,
+                                  int32_t salt_length, uint32_t iteration_count, uint8_t *key, uint16_t key_length);
 
 /***************************************************************************/
-
-int32_t mz_crypt_rand(uint8_t *buf, int32_t size);
-
-void mz_crypt_sha_reset(void *handle);
-int32_t mz_crypt_sha_begin(void *handle);
-int32_t mz_crypt_sha_update(void *handle, const void *buf, int32_t size);
-int32_t mz_crypt_sha_end(void *handle, uint8_t *digest, int32_t digest_size);
-int32_t mz_crypt_sha_set_algorithm(void *handle, uint16_t algorithm);
-void *mz_crypt_sha_create(void);
-void mz_crypt_sha_delete(void **handle);
-
-void mz_crypt_aes_reset(void *handle);
-int32_t mz_crypt_aes_encrypt(void *handle, const void *aad, int32_t aad_size, uint8_t *buf, int32_t size);
-int32_t mz_crypt_aes_encrypt_final(void *handle, uint8_t *buf, int32_t size, uint8_t *tag, int32_t tag_size);
-int32_t mz_crypt_aes_decrypt(void *handle, const void *aad, int32_t aad_size, uint8_t *buf, int32_t size);
-int32_t mz_crypt_aes_decrypt_final(void *handle, uint8_t *buf, int32_t size, const uint8_t *tag, int32_t tag_size);
-int32_t mz_crypt_aes_set_encrypt_key(void *handle, const void *key, int32_t key_length, const void *iv,
-                                     int32_t iv_length);
-int32_t mz_crypt_aes_set_decrypt_key(void *handle, const void *key, int32_t key_length, const void *iv,
-                                     int32_t iv_length);
-void mz_crypt_aes_set_mode(void *handle, int32_t mode);
-void *mz_crypt_aes_create(void);
-void mz_crypt_aes_delete(void **handle);
-
-void mz_crypt_hmac_reset(void *handle);
-int32_t mz_crypt_hmac_init(void *handle, const void *key, int32_t key_length);
-int32_t mz_crypt_hmac_update(void *handle, const void *buf, int32_t size);
-int32_t mz_crypt_hmac_end(void *handle, uint8_t *digest, int32_t digest_size);
-int32_t mz_crypt_hmac_copy(void *src_handle, void *target_handle);
-void mz_crypt_hmac_set_algorithm(void *handle, uint16_t algorithm);
-void *mz_crypt_hmac_create(void);
-void mz_crypt_hmac_delete(void **handle);
+MZ_EXPORT int32_t mz_crypt_rand(uint8_t *buf, int32_t size);
+MZ_EXPORT void mz_crypt_sha_reset(void *handle);
+MZ_EXPORT int32_t mz_crypt_sha_begin(void *handle);
+MZ_EXPORT int32_t mz_crypt_sha_update(void *handle, const void *buf, int32_t size);
+MZ_EXPORT int32_t mz_crypt_sha_end(void *handle, uint8_t *digest, int32_t digest_size);
+MZ_EXPORT int32_t mz_crypt_sha_set_algorithm(void *handle, uint16_t algorithm);
+MZ_EXPORT void *mz_crypt_sha_create(void);
+MZ_EXPORT void mz_crypt_sha_delete(void **handle);
+MZ_EXPORT void mz_crypt_aes_reset(void *handle);
+MZ_EXPORT int32_t mz_crypt_aes_encrypt(void *handle, const void *aad, int32_t aad_size, uint8_t *buf, int32_t size);
+MZ_EXPORT int32_t mz_crypt_aes_encrypt_final(void *handle, uint8_t *buf, int32_t size, uint8_t *tag, int32_t tag_size);
+MZ_EXPORT int32_t mz_crypt_aes_decrypt(void *handle, const void *aad, int32_t aad_size, uint8_t *buf, int32_t size);
+MZ_EXPORT int32_t mz_crypt_aes_decrypt_final(void *handle, uint8_t *buf, int32_t size, const uint8_t *tag,
+                                             int32_t tag_size);
+MZ_EXPORT int32_t mz_crypt_aes_set_encrypt_key(void *handle, const void *key, int32_t key_length, const void *iv,
+                                               int32_t iv_length);
+MZ_EXPORT int32_t mz_crypt_aes_set_decrypt_key(void *handle, const void *key, int32_t key_length, const void *iv,
+                                               int32_t iv_length);
+MZ_EXPORT void mz_crypt_aes_set_mode(void *handle, int32_t mode);
+MZ_EXPORT void *mz_crypt_aes_create(void);
+MZ_EXPORT void mz_crypt_aes_delete(void **handle);
+MZ_EXPORT void mz_crypt_hmac_reset(void *handle);
+MZ_EXPORT int32_t mz_crypt_hmac_init(void *handle, const void *key, int32_t key_length);
+MZ_EXPORT int32_t mz_crypt_hmac_update(void *handle, const void *buf, int32_t size);
+MZ_EXPORT int32_t mz_crypt_hmac_end(void *handle, uint8_t *digest, int32_t digest_size);
+MZ_EXPORT int32_t mz_crypt_hmac_copy(void *src_handle, void *target_handle);
+MZ_EXPORT void mz_crypt_hmac_set_algorithm(void *handle, uint16_t algorithm);
+MZ_EXPORT void *mz_crypt_hmac_create(void);
+MZ_EXPORT void mz_crypt_hmac_delete(void **handle);
 
 /***************************************************************************/
 

--- a/mz_os.h
+++ b/mz_os.h
@@ -69,127 +69,90 @@ extern "C" {
 
 /***************************************************************************/
 /* Shared functions */
-
-int32_t mz_path_combine(char *path, const char *join, int32_t max_path);
+MZ_EXPORT int32_t mz_path_combine(char *path, const char *join, int32_t max_path);
 /* Combines two paths */
-
-int32_t mz_path_append_slash(char *path, int32_t max_path, char slash);
+MZ_EXPORT int32_t mz_path_append_slash(char *path, int32_t max_path, char slash);
 /* Appends a path slash on to the end of the path */
-
-int32_t mz_path_remove_slash(char *path);
+MZ_EXPORT int32_t mz_path_remove_slash(char *path);
 /* Removes a path slash from the end of the path */
-
-int32_t mz_path_has_slash(const char *path);
+MZ_EXPORT int32_t mz_path_has_slash(const char *path);
 /* Returns whether or not the path ends with slash */
-
-int32_t mz_path_convert_slashes(char *path, char slash);
+MZ_EXPORT int32_t mz_path_convert_slashes(char *path, char slash);
 /* Converts the slashes in a path */
-
-int32_t mz_path_compare_wc(const char *path, const char *wildcard, uint8_t ignore_case);
+MZ_EXPORT int32_t mz_path_compare_wc(const char *path, const char *wildcard, uint8_t ignore_case);
 /* Compare two paths with wildcard */
-
-int32_t mz_path_resolve(const char *path, char *target, int32_t max_target);
+MZ_EXPORT int32_t mz_path_resolve(const char *path, char *target, int32_t max_target);
 /* Resolves path */
-
-int32_t mz_path_remove_filename(char *path);
+MZ_EXPORT int32_t mz_path_remove_filename(char *path);
 /* Remove the filename from a path */
-
-int32_t mz_path_remove_extension(char *path);
+MZ_EXPORT int32_t mz_path_remove_extension(char *path);
 /* Remove the extension from a path */
-
-int32_t mz_path_get_filename(const char *path, const char **filename);
+MZ_EXPORT int32_t mz_path_get_filename(const char *path, const char **filename);
 /* Get the filename from a path */
-
-int32_t mz_path_is_symlink_target_safe(const char *link_path, const char *target, const char *base_path);
+MZ_EXPORT int32_t mz_path_is_symlink_target_safe(const char *link_path, const char *target, const char *base_path);
 /* Checks if a symlink target resolves within base path. */
-
-int32_t mz_dir_has_unsafe_symlink(const char *path, const char *base_path);
+MZ_EXPORT int32_t mz_dir_has_unsafe_symlink(const char *path, const char *base_path);
 /* Checks if any existing component of path is a symlink that escapes base path. */
-
-int32_t mz_dir_make(const char *path);
+MZ_EXPORT int32_t mz_dir_make(const char *path);
 /* Creates a directory recursively */
-
-int32_t mz_file_get_crc(const char *path, uint32_t *result_crc);
+MZ_EXPORT int32_t mz_file_get_crc(const char *path, uint32_t *result_crc);
 /* Gets the crc32 hash of a file */
 
 /***************************************************************************/
 /* Platform specific functions */
-
-wchar_t *mz_os_unicode_string_create(const char *string, int32_t encoding);
+MZ_EXPORT wchar_t *mz_os_unicode_string_create(const char *string, int32_t encoding);
 /* Create unicode string from a utf8 string */
-
-void mz_os_unicode_string_delete(wchar_t **string);
+MZ_EXPORT void mz_os_unicode_string_delete(wchar_t **string);
 /* Delete a unicode string that was created */
-
-char *mz_os_utf8_string_create(const char *string, int32_t encoding);
+MZ_EXPORT char *mz_os_utf8_string_create(const char *string, int32_t encoding);
 /* Create a utf8 string from a string with another encoding */
-
-void mz_os_utf8_string_delete(char **string);
+MZ_EXPORT void mz_os_utf8_string_delete(char **string);
 /* Delete a utf8 string that was created */
-
-int32_t mz_os_rand(uint8_t *buf, int32_t size);
+MZ_EXPORT int32_t mz_os_rand(uint8_t *buf, int32_t size);
 /* Random number generator (not cryptographically secure) */
-
-int32_t mz_os_rename(const char *source_path, const char *target_path);
+MZ_EXPORT int32_t mz_os_rename(const char *source_path, const char *target_path);
 /* Rename a file */
-
-int32_t mz_os_unlink(const char *path);
+MZ_EXPORT int32_t mz_os_unlink(const char *path);
 /* Delete an existing file  */
-
-int32_t mz_os_file_exists(const char *path);
+MZ_EXPORT int32_t mz_os_file_exists(const char *path);
 /* Check to see if a file exists */
-
-int64_t mz_os_get_file_size(const char *path);
+MZ_EXPORT int64_t mz_os_get_file_size(const char *path);
 /* Gets the length of a file */
-
-int32_t mz_os_get_file_date(const char *path, time_t *modified_date, time_t *accessed_date, time_t *creation_date);
+MZ_EXPORT int32_t mz_os_get_file_date(const char *path, time_t *modified_date, time_t *accessed_date,
+                                      time_t *creation_date);
 /* Gets a file's modified, access, and creation dates if supported */
-
-int32_t mz_os_set_file_date(const char *path, time_t modified_date, time_t accessed_date, time_t creation_date);
+MZ_EXPORT int32_t mz_os_set_file_date(const char *path, time_t modified_date, time_t accessed_date,
+                                      time_t creation_date);
 /* Sets a file's modified, access, and creation dates if supported */
-
-int32_t mz_os_get_file_attribs(const char *path, uint32_t *attributes);
+MZ_EXPORT int32_t mz_os_get_file_attribs(const char *path, uint32_t *attributes);
 /* Gets a file's attributes, following symbolic links */
-
-int32_t mz_os_set_file_attribs(const char *path, uint32_t attributes);
+MZ_EXPORT int32_t mz_os_set_file_attribs(const char *path, uint32_t attributes);
 /* Sets a file's attributes */
-
-int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix);
+MZ_EXPORT int32_t mz_os_get_temp_path(char *path, int32_t max_path, const char *prefix);
 /* Gets a unique temporary file path */
-
-int32_t mz_os_path_same_fs(const char *path_a, const char *path_b);
+MZ_EXPORT int32_t mz_os_path_same_fs(const char *path_a, const char *path_b);
 /* Checks if both paths are on the same filesystem */
-
-int32_t mz_os_make_dir(const char *path);
+MZ_EXPORT int32_t mz_os_make_dir(const char *path);
 /* Recursively creates a directory */
-
-DIR *mz_os_open_dir(const char *path);
+MZ_EXPORT DIR *mz_os_open_dir(const char *path);
 /* Opens a directory for listing */
-struct dirent *mz_os_read_dir(DIR *dir);
+MZ_EXPORT struct dirent *mz_os_read_dir(DIR *dir);
 /* Reads a directory listing entry */
-
-int32_t mz_os_close_dir(DIR *dir);
+MZ_EXPORT int32_t mz_os_close_dir(DIR *dir);
 /* Closes a directory that has been opened for listing */
-
-int32_t mz_os_is_dir_separator(char c);
+MZ_EXPORT int32_t mz_os_is_dir_separator(char c);
 /* Checks to see if character is a directory separator */
-
-int32_t mz_os_is_dir(const char *path);
+MZ_EXPORT int32_t mz_os_is_dir(const char *path);
 /* Checks to see if path is a directory */
-
-int32_t mz_os_is_symlink(const char *path);
+MZ_EXPORT int32_t mz_os_is_symlink(const char *path);
 /* Checks to see if path is a symbolic link */
-
-int32_t mz_os_get_link_attribs(const char *path, uint32_t *attributes);
+MZ_EXPORT int32_t mz_os_get_link_attribs(const char *path, uint32_t *attributes);
 /* Gets a symbolic link's attributes */
-
-int32_t mz_os_make_symlink(const char *path, const char *target_path);
+MZ_EXPORT int32_t mz_os_make_symlink(const char *path, const char *target_path);
 /* Creates a symbolic link pointing to a target */
-
-int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_target_path);
+MZ_EXPORT int32_t mz_os_read_symlink(const char *path, char *target_path, int32_t max_target_path);
 /* Gets the target path for a symbolic link */
-
-uint64_t mz_os_ms_time(void);
+MZ_EXPORT uint64_t mz_os_ms_time(void);
 /* Gets the time in milliseconds */
 
 /***************************************************************************/

--- a/mz_strm.h
+++ b/mz_strm.h
@@ -73,58 +73,54 @@ typedef struct mz_stream_s {
 } mz_stream;
 
 /***************************************************************************/
-
-int32_t mz_stream_open(void *stream, const char *path, int32_t mode);
-int32_t mz_stream_is_open(void *stream);
-int32_t mz_stream_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_read_uint8(void *stream, uint8_t *value);
-int32_t mz_stream_read_uint16(void *stream, uint16_t *value);
-int32_t mz_stream_read_uint32(void *stream, uint32_t *value);
-int32_t mz_stream_read_int64(void *stream, int64_t *value);
-int32_t mz_stream_read_uint64(void *stream, uint64_t *value);
-int32_t mz_stream_write(void *stream, const void *buf, int32_t size);
-int32_t mz_stream_write_uint8(void *stream, uint8_t value);
-int32_t mz_stream_write_uint16(void *stream, uint16_t value);
-int32_t mz_stream_write_uint32(void *stream, uint32_t value);
-int32_t mz_stream_write_int64(void *stream, int64_t value);
-int32_t mz_stream_write_uint64(void *stream, uint64_t value);
-int32_t mz_stream_copy(void *target, void *source, int32_t len);
-int32_t mz_stream_copy_to_end(void *target, void *source);
-int32_t mz_stream_copy_stream(void *target, mz_stream_write_cb write_cb, void *source, mz_stream_read_cb read_cb,
-                              int32_t len);
-int32_t mz_stream_copy_stream_to_end(void *target, mz_stream_write_cb write_cb, void *source,
-                                     mz_stream_read_cb read_cb);
-int64_t mz_stream_tell(void *stream);
-int32_t mz_stream_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_find(void *stream, const void *find, int32_t find_size, int64_t max_seek, int64_t *position);
-int32_t mz_stream_find_reverse(void *stream, const void *find, int32_t find_size, int64_t max_seek, int64_t *position);
-int32_t mz_stream_close(void *stream);
-int32_t mz_stream_error(void *stream);
-
-int32_t mz_stream_set_base(void *stream, void *base);
-void *mz_stream_get_interface(void *stream);
-int32_t mz_stream_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_set_prop_int64(void *stream, int32_t prop, int64_t value);
-
-void *mz_stream_create(mz_stream_vtbl *vtbl);
-void mz_stream_delete(void **stream);
+MZ_EXPORT int32_t mz_stream_open(void *stream, const char *path, int32_t mode);
+MZ_EXPORT int32_t mz_stream_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_read_uint8(void *stream, uint8_t *value);
+MZ_EXPORT int32_t mz_stream_read_uint16(void *stream, uint16_t *value);
+MZ_EXPORT int32_t mz_stream_read_uint32(void *stream, uint32_t *value);
+MZ_EXPORT int32_t mz_stream_read_int64(void *stream, int64_t *value);
+MZ_EXPORT int32_t mz_stream_read_uint64(void *stream, uint64_t *value);
+MZ_EXPORT int32_t mz_stream_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_write_uint8(void *stream, uint8_t value);
+MZ_EXPORT int32_t mz_stream_write_uint16(void *stream, uint16_t value);
+MZ_EXPORT int32_t mz_stream_write_uint32(void *stream, uint32_t value);
+MZ_EXPORT int32_t mz_stream_write_int64(void *stream, int64_t value);
+MZ_EXPORT int32_t mz_stream_write_uint64(void *stream, uint64_t value);
+MZ_EXPORT int32_t mz_stream_copy(void *target, void *source, int32_t len);
+MZ_EXPORT int32_t mz_stream_copy_to_end(void *target, void *source);
+MZ_EXPORT int32_t mz_stream_copy_stream(void *target, mz_stream_write_cb write_cb, void *source,
+                                        mz_stream_read_cb read_cb, int32_t len);
+MZ_EXPORT int32_t mz_stream_copy_stream_to_end(void *target, mz_stream_write_cb write_cb, void *source,
+                                               mz_stream_read_cb read_cb);
+MZ_EXPORT int64_t mz_stream_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_find(void *stream, const void *find, int32_t find_size, int64_t max_seek,
+                                 int64_t *position);
+MZ_EXPORT int32_t mz_stream_find_reverse(void *stream, const void *find, int32_t find_size, int64_t max_seek,
+                                         int64_t *position);
+MZ_EXPORT int32_t mz_stream_close(void *stream);
+MZ_EXPORT int32_t mz_stream_error(void *stream);
+MZ_EXPORT int32_t mz_stream_set_base(void *stream, void *base);
+MZ_EXPORT void *mz_stream_get_interface(void *stream);
+MZ_EXPORT int32_t mz_stream_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_create(mz_stream_vtbl *vtbl);
+MZ_EXPORT void mz_stream_delete(void **stream);
 
 /***************************************************************************/
-
-int32_t mz_stream_raw_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_raw_is_open(void *stream);
-int32_t mz_stream_raw_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_raw_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_raw_tell(void *stream);
-int32_t mz_stream_raw_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_raw_close(void *stream);
-int32_t mz_stream_raw_error(void *stream);
-
-int32_t mz_stream_raw_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_raw_set_prop_int64(void *stream, int32_t prop, int64_t value);
-
-void *mz_stream_raw_create(void);
-void mz_stream_raw_delete(void **stream);
+MZ_EXPORT int32_t mz_stream_raw_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_raw_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_raw_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_raw_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_raw_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_raw_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_raw_close(void *stream);
+MZ_EXPORT int32_t mz_stream_raw_error(void *stream);
+MZ_EXPORT int32_t mz_stream_raw_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_raw_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_raw_create(void);
+MZ_EXPORT void mz_stream_raw_delete(void **stream);
 
 /***************************************************************************/
 

--- a/mz_strm_buf.h
+++ b/mz_strm_buf.h
@@ -18,20 +18,19 @@ extern "C" {
 #endif
 
 /***************************************************************************/
+MZ_EXPORT int32_t mz_stream_buffered_open(void *stream, const char *path, int32_t mode);
+MZ_EXPORT int32_t mz_stream_buffered_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_buffered_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_buffered_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_buffered_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_buffered_close(void *stream);
+MZ_EXPORT int32_t mz_stream_buffered_error(void *stream);
 
-int32_t mz_stream_buffered_open(void *stream, const char *path, int32_t mode);
-int32_t mz_stream_buffered_is_open(void *stream);
-int32_t mz_stream_buffered_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_buffered_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_buffered_tell(void *stream);
-int32_t mz_stream_buffered_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_buffered_close(void *stream);
-int32_t mz_stream_buffered_error(void *stream);
+MZ_EXPORT void *mz_stream_buffered_create(void);
+MZ_EXPORT void mz_stream_buffered_delete(void **stream);
 
-void *mz_stream_buffered_create(void);
-void mz_stream_buffered_delete(void **stream);
-
-void *mz_stream_buffered_get_interface(void);
+MZ_EXPORT void *mz_stream_buffered_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_bzip.h
+++ b/mz_strm_bzip.h
@@ -16,25 +16,20 @@ extern "C" {
 #endif
 
 /***************************************************************************/
-
-int32_t mz_stream_bzip_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_bzip_is_open(void *stream);
-int32_t mz_stream_bzip_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_bzip_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_bzip_tell(void *stream);
-int32_t mz_stream_bzip_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_bzip_close(void *stream);
-int32_t mz_stream_bzip_error(void *stream);
-
-int32_t mz_stream_bzip_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_bzip_set_prop_int64(void *stream, int32_t prop, int64_t value);
-
-void *mz_stream_bzip_create(void);
-void mz_stream_bzip_delete(void **stream);
-
-void *mz_stream_bzip_get_interface(void);
-
-void bz_internal_error(int errcode);
+MZ_EXPORT int32_t mz_stream_bzip_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_bzip_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_bzip_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_bzip_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_bzip_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_bzip_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_bzip_close(void *stream);
+MZ_EXPORT int32_t mz_stream_bzip_error(void *stream);
+MZ_EXPORT int32_t mz_stream_bzip_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_bzip_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_bzip_create(void);
+MZ_EXPORT void mz_stream_bzip_delete(void **stream);
+MZ_EXPORT void *mz_stream_bzip_get_interface(void);
+MZ_EXPORT void bz_internal_error(int errcode);
 
 /***************************************************************************/
 

--- a/mz_strm_libcomp.h
+++ b/mz_strm_libcomp.h
@@ -16,23 +16,19 @@ extern "C" {
 #endif
 
 /***************************************************************************/
-
-int32_t mz_stream_libcomp_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_libcomp_is_open(void *stream);
-int32_t mz_stream_libcomp_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_libcomp_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_libcomp_tell(void *stream);
-int32_t mz_stream_libcomp_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_libcomp_close(void *stream);
-int32_t mz_stream_libcomp_error(void *stream);
-
-int32_t mz_stream_libcomp_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_libcomp_set_prop_int64(void *stream, int32_t prop, int64_t value);
-
-void *mz_stream_libcomp_create(void);
-void mz_stream_libcomp_delete(void **stream);
-
-void *mz_stream_libcomp_get_interface(void);
+MZ_EXPORT int32_t mz_stream_libcomp_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_libcomp_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_libcomp_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_libcomp_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_libcomp_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_libcomp_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_libcomp_close(void *stream);
+MZ_EXPORT int32_t mz_stream_libcomp_error(void *stream);
+MZ_EXPORT int32_t mz_stream_libcomp_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_libcomp_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_libcomp_create(void);
+MZ_EXPORT void mz_stream_libcomp_delete(void **stream);
+MZ_EXPORT void *mz_stream_libcomp_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_lzma.h
+++ b/mz_strm_lzma.h
@@ -16,23 +16,19 @@ extern "C" {
 #endif
 
 /***************************************************************************/
-
-int32_t mz_stream_lzma_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_lzma_is_open(void *stream);
-int32_t mz_stream_lzma_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_lzma_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_lzma_tell(void *stream);
-int32_t mz_stream_lzma_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_lzma_close(void *stream);
-int32_t mz_stream_lzma_error(void *stream);
-
-int32_t mz_stream_lzma_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_lzma_set_prop_int64(void *stream, int32_t prop, int64_t value);
-
-void *mz_stream_lzma_create(void);
-void mz_stream_lzma_delete(void **stream);
-
-void *mz_stream_lzma_get_interface(void);
+MZ_EXPORT int32_t mz_stream_lzma_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_lzma_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_lzma_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_lzma_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_lzma_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_lzma_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_lzma_close(void *stream);
+MZ_EXPORT int32_t mz_stream_lzma_error(void *stream);
+MZ_EXPORT int32_t mz_stream_lzma_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_lzma_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_lzma_create(void);
+MZ_EXPORT void mz_stream_lzma_delete(void **stream);
+MZ_EXPORT void *mz_stream_lzma_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_mem.h
+++ b/mz_strm_mem.h
@@ -16,28 +16,27 @@ extern "C" {
 #endif
 
 /***************************************************************************/
+MZ_EXPORT int32_t mz_stream_mem_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_mem_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_mem_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_mem_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_mem_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_mem_close(void *stream);
+MZ_EXPORT int32_t mz_stream_mem_error(void *stream);
 
-int32_t mz_stream_mem_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_mem_is_open(void *stream);
-int32_t mz_stream_mem_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_mem_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_mem_tell(void *stream);
-int32_t mz_stream_mem_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_mem_close(void *stream);
-int32_t mz_stream_mem_error(void *stream);
+MZ_EXPORT void mz_stream_mem_set_buffer(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_mem_get_buffer(void *stream, const void **buf);
+MZ_EXPORT int32_t mz_stream_mem_get_buffer_at(void *stream, int64_t position, const void **buf);
+MZ_EXPORT int32_t mz_stream_mem_get_buffer_at_current(void *stream, const void **buf);
+MZ_EXPORT void mz_stream_mem_get_buffer_length(void *stream, int32_t *length);
+MZ_EXPORT void mz_stream_mem_set_buffer_limit(void *stream, int32_t limit);
+MZ_EXPORT void mz_stream_mem_set_grow_size(void *stream, int32_t grow_size);
 
-void mz_stream_mem_set_buffer(void *stream, void *buf, int32_t size);
-int32_t mz_stream_mem_get_buffer(void *stream, const void **buf);
-int32_t mz_stream_mem_get_buffer_at(void *stream, int64_t position, const void **buf);
-int32_t mz_stream_mem_get_buffer_at_current(void *stream, const void **buf);
-void mz_stream_mem_get_buffer_length(void *stream, int32_t *length);
-void mz_stream_mem_set_buffer_limit(void *stream, int32_t limit);
-void mz_stream_mem_set_grow_size(void *stream, int32_t grow_size);
+MZ_EXPORT void *mz_stream_mem_create(void);
+MZ_EXPORT void mz_stream_mem_delete(void **stream);
 
-void *mz_stream_mem_create(void);
-void mz_stream_mem_delete(void **stream);
-
-void *mz_stream_mem_get_interface(void);
+MZ_EXPORT void *mz_stream_mem_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_os.h
+++ b/mz_strm_os.h
@@ -16,20 +16,19 @@ extern "C" {
 #endif
 
 /***************************************************************************/
+MZ_EXPORT int32_t mz_stream_os_open(void *stream, const char *path, int32_t mode);
+MZ_EXPORT int32_t mz_stream_os_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_os_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_os_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_os_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_os_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_os_close(void *stream);
+MZ_EXPORT int32_t mz_stream_os_error(void *stream);
 
-int32_t mz_stream_os_open(void *stream, const char *path, int32_t mode);
-int32_t mz_stream_os_is_open(void *stream);
-int32_t mz_stream_os_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_os_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_os_tell(void *stream);
-int32_t mz_stream_os_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_os_close(void *stream);
-int32_t mz_stream_os_error(void *stream);
+MZ_EXPORT void *mz_stream_os_create(void);
+MZ_EXPORT void mz_stream_os_delete(void **stream);
 
-void *mz_stream_os_create(void);
-void mz_stream_os_delete(void **stream);
-
-void *mz_stream_os_get_interface(void);
+MZ_EXPORT void *mz_stream_os_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_pkcrypt.h
+++ b/mz_strm_pkcrypt.h
@@ -16,26 +16,25 @@ extern "C" {
 #endif
 
 /***************************************************************************/
+MZ_EXPORT int32_t mz_stream_pkcrypt_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_pkcrypt_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_pkcrypt_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_pkcrypt_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_pkcrypt_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_pkcrypt_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_pkcrypt_close(void *stream);
+MZ_EXPORT int32_t mz_stream_pkcrypt_error(void *stream);
 
-int32_t mz_stream_pkcrypt_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_pkcrypt_is_open(void *stream);
-int32_t mz_stream_pkcrypt_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_pkcrypt_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_pkcrypt_tell(void *stream);
-int32_t mz_stream_pkcrypt_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_pkcrypt_close(void *stream);
-int32_t mz_stream_pkcrypt_error(void *stream);
+MZ_EXPORT void mz_stream_pkcrypt_set_password(void *stream, const char *password);
+MZ_EXPORT void mz_stream_pkcrypt_set_verify(void *stream, uint8_t verify1, uint8_t verify2, uint16_t version);
+MZ_EXPORT void mz_stream_pkcrypt_get_verify(void *stream, uint8_t *verify1, uint8_t *verify2, uint16_t *version);
+MZ_EXPORT int32_t mz_stream_pkcrypt_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_pkcrypt_set_prop_int64(void *stream, int32_t prop, int64_t value);
 
-void mz_stream_pkcrypt_set_password(void *stream, const char *password);
-void mz_stream_pkcrypt_set_verify(void *stream, uint8_t verify1, uint8_t verify2, uint16_t version);
-void mz_stream_pkcrypt_get_verify(void *stream, uint8_t *verify1, uint8_t *verify2, uint16_t *version);
-int32_t mz_stream_pkcrypt_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_pkcrypt_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_pkcrypt_create(void);
+MZ_EXPORT void mz_stream_pkcrypt_delete(void **stream);
 
-void *mz_stream_pkcrypt_create(void);
-void mz_stream_pkcrypt_delete(void **stream);
-
-void *mz_stream_pkcrypt_get_interface(void);
+MZ_EXPORT void *mz_stream_pkcrypt_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_ppmd.h
+++ b/mz_strm_ppmd.h
@@ -16,23 +16,22 @@ extern "C" {
 #endif
 
 /***************************************************************************/
+MZ_EXPORT int32_t mz_stream_ppmd_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_ppmd_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_ppmd_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_ppmd_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_ppmd_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_ppmd_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_ppmd_close(void *stream);
+MZ_EXPORT int32_t mz_stream_ppmd_error(void *stream);
 
-int32_t mz_stream_ppmd_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_ppmd_is_open(void *stream);
-int32_t mz_stream_ppmd_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_ppmd_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_ppmd_tell(void *stream);
-int32_t mz_stream_ppmd_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_ppmd_close(void *stream);
-int32_t mz_stream_ppmd_error(void *stream);
+MZ_EXPORT int32_t mz_stream_ppmd_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_ppmd_set_prop_int64(void *stream, int32_t prop, int64_t value);
 
-int32_t mz_stream_ppmd_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_ppmd_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_ppmd_create(void);
+MZ_EXPORT void mz_stream_ppmd_delete(void **stream);
 
-void *mz_stream_ppmd_create(void);
-void mz_stream_ppmd_delete(void **stream);
-
-void *mz_stream_ppmd_get_interface(void);
+MZ_EXPORT void *mz_stream_ppmd_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_split.h
+++ b/mz_strm_split.h
@@ -16,23 +16,22 @@ extern "C" {
 #endif
 
 /***************************************************************************/
+MZ_EXPORT int32_t mz_stream_split_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_split_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_split_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_split_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_split_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_split_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_split_close(void *stream);
+MZ_EXPORT int32_t mz_stream_split_error(void *stream);
 
-int32_t mz_stream_split_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_split_is_open(void *stream);
-int32_t mz_stream_split_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_split_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_split_tell(void *stream);
-int32_t mz_stream_split_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_split_close(void *stream);
-int32_t mz_stream_split_error(void *stream);
+MZ_EXPORT int32_t mz_stream_split_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_split_set_prop_int64(void *stream, int32_t prop, int64_t value);
 
-int32_t mz_stream_split_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_split_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_split_create(void);
+MZ_EXPORT void mz_stream_split_delete(void **stream);
 
-void *mz_stream_split_create(void);
-void mz_stream_split_delete(void **stream);
-
-void *mz_stream_split_get_interface(void);
+MZ_EXPORT void *mz_stream_split_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_wzaes.h
+++ b/mz_strm_wzaes.h
@@ -16,26 +16,25 @@ extern "C" {
 #endif
 
 /***************************************************************************/
+MZ_EXPORT int32_t mz_stream_wzaes_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_wzaes_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_wzaes_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_wzaes_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_wzaes_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_wzaes_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_wzaes_close(void *stream);
+MZ_EXPORT int32_t mz_stream_wzaes_error(void *stream);
 
-int32_t mz_stream_wzaes_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_wzaes_is_open(void *stream);
-int32_t mz_stream_wzaes_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_wzaes_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_wzaes_tell(void *stream);
-int32_t mz_stream_wzaes_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_wzaes_close(void *stream);
-int32_t mz_stream_wzaes_error(void *stream);
+MZ_EXPORT void mz_stream_wzaes_set_password(void *stream, const char *password);
+MZ_EXPORT void mz_stream_wzaes_set_strength(void *stream, uint8_t strength);
 
-void mz_stream_wzaes_set_password(void *stream, const char *password);
-void mz_stream_wzaes_set_strength(void *stream, uint8_t strength);
+MZ_EXPORT int32_t mz_stream_wzaes_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_wzaes_set_prop_int64(void *stream, int32_t prop, int64_t value);
 
-int32_t mz_stream_wzaes_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_wzaes_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_wzaes_create(void);
+MZ_EXPORT void mz_stream_wzaes_delete(void **stream);
 
-void *mz_stream_wzaes_create(void);
-void mz_stream_wzaes_delete(void **stream);
-
-void *mz_stream_wzaes_get_interface(void);
+MZ_EXPORT void *mz_stream_wzaes_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_zlib.h
+++ b/mz_strm_zlib.h
@@ -16,23 +16,22 @@ extern "C" {
 #endif
 
 /***************************************************************************/
+MZ_EXPORT int32_t mz_stream_zlib_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_zlib_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_zlib_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_zlib_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_zlib_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_zlib_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_zlib_close(void *stream);
+MZ_EXPORT int32_t mz_stream_zlib_error(void *stream);
 
-int32_t mz_stream_zlib_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_zlib_is_open(void *stream);
-int32_t mz_stream_zlib_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_zlib_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_zlib_tell(void *stream);
-int32_t mz_stream_zlib_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_zlib_close(void *stream);
-int32_t mz_stream_zlib_error(void *stream);
+MZ_EXPORT int32_t mz_stream_zlib_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_zlib_set_prop_int64(void *stream, int32_t prop, int64_t value);
 
-int32_t mz_stream_zlib_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_zlib_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_zlib_create(void);
+MZ_EXPORT void mz_stream_zlib_delete(void **stream);
 
-void *mz_stream_zlib_create(void);
-void mz_stream_zlib_delete(void **stream);
-
-void *mz_stream_zlib_get_interface(void);
+MZ_EXPORT void *mz_stream_zlib_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_strm_zstd.h
+++ b/mz_strm_zstd.h
@@ -17,23 +17,22 @@ extern "C" {
 #endif
 
 /***************************************************************************/
+MZ_EXPORT int32_t mz_stream_zstd_open(void *stream, const char *filename, int32_t mode);
+MZ_EXPORT int32_t mz_stream_zstd_is_open(void *stream);
+MZ_EXPORT int32_t mz_stream_zstd_read(void *stream, void *buf, int32_t size);
+MZ_EXPORT int32_t mz_stream_zstd_write(void *stream, const void *buf, int32_t size);
+MZ_EXPORT int64_t mz_stream_zstd_tell(void *stream);
+MZ_EXPORT int32_t mz_stream_zstd_seek(void *stream, int64_t offset, int32_t origin);
+MZ_EXPORT int32_t mz_stream_zstd_close(void *stream);
+MZ_EXPORT int32_t mz_stream_zstd_error(void *stream);
 
-int32_t mz_stream_zstd_open(void *stream, const char *filename, int32_t mode);
-int32_t mz_stream_zstd_is_open(void *stream);
-int32_t mz_stream_zstd_read(void *stream, void *buf, int32_t size);
-int32_t mz_stream_zstd_write(void *stream, const void *buf, int32_t size);
-int64_t mz_stream_zstd_tell(void *stream);
-int32_t mz_stream_zstd_seek(void *stream, int64_t offset, int32_t origin);
-int32_t mz_stream_zstd_close(void *stream);
-int32_t mz_stream_zstd_error(void *stream);
+MZ_EXPORT int32_t mz_stream_zstd_get_prop_int64(void *stream, int32_t prop, int64_t *value);
+MZ_EXPORT int32_t mz_stream_zstd_set_prop_int64(void *stream, int32_t prop, int64_t value);
 
-int32_t mz_stream_zstd_get_prop_int64(void *stream, int32_t prop, int64_t *value);
-int32_t mz_stream_zstd_set_prop_int64(void *stream, int32_t prop, int64_t value);
+MZ_EXPORT void *mz_stream_zstd_create(void);
+MZ_EXPORT void mz_stream_zstd_delete(void **stream);
 
-void *mz_stream_zstd_create(void);
-void mz_stream_zstd_delete(void **stream);
-
-void *mz_stream_zstd_get_interface(void);
+MZ_EXPORT void *mz_stream_zstd_get_interface(void);
 
 /***************************************************************************/
 

--- a/mz_zip.h
+++ b/mz_zip.h
@@ -56,196 +56,200 @@ typedef int32_t (*mz_zip_locate_entry_cb)(void *handle, void *userdata, mz_zip_f
 
 /***************************************************************************/
 
-void *mz_zip_create(void);
+MZ_EXPORT void *mz_zip_create(void);
 /* Create zip instance for opening */
 
-void mz_zip_delete(void **handle);
+MZ_EXPORT void mz_zip_delete(void **handle);
 /* Delete zip object */
 
-int32_t mz_zip_open(void *handle, void *stream, int32_t mode);
+MZ_EXPORT int32_t mz_zip_open(void *handle, void *stream, int32_t mode);
 /* Create a zip file, no delete file in zip functionality */
 
-int32_t mz_zip_close(void *handle);
+MZ_EXPORT int32_t mz_zip_close(void *handle);
 /* Close the zip file */
 
-int32_t mz_zip_get_comment(void *handle, const char **comment);
+MZ_EXPORT int32_t mz_zip_get_comment(void *handle, const char **comment);
 /* Get a pointer to the global comment */
 
-int32_t mz_zip_set_comment(void *handle, const char *comment);
+MZ_EXPORT int32_t mz_zip_set_comment(void *handle, const char *comment);
 /* Sets the global comment used for writing zip file */
 
-int32_t mz_zip_get_version_madeby(void *handle, uint16_t *version_madeby);
+MZ_EXPORT int32_t mz_zip_get_version_madeby(void *handle, uint16_t *version_madeby);
 /* Get the version made by */
 
-int32_t mz_zip_set_version_madeby(void *handle, uint16_t version_madeby);
+MZ_EXPORT int32_t mz_zip_set_version_madeby(void *handle, uint16_t version_madeby);
 /* Sets the version made by used for writing zip file */
 
-int32_t mz_zip_set_recover(void *handle, uint8_t recover);
+MZ_EXPORT int32_t mz_zip_set_recover(void *handle, uint8_t recover);
 /* Sets the ability to recover the central dir by reading local file headers */
 
-int32_t mz_zip_set_data_descriptor(void *handle, uint8_t data_descriptor);
+MZ_EXPORT int32_t mz_zip_set_data_descriptor(void *handle, uint8_t data_descriptor);
 /* Sets the use of data descriptor flag when writing zip entries */
 
-int32_t mz_zip_get_stream(void *handle, void **stream);
+MZ_EXPORT int32_t mz_zip_get_stream(void *handle, void **stream);
 /* Get a pointer to the stream used to open */
 
-int32_t mz_zip_set_cd_stream(void *handle, int64_t cd_start_pos, void *cd_stream);
+MZ_EXPORT int32_t mz_zip_set_cd_stream(void *handle, int64_t cd_start_pos, void *cd_stream);
 /* Sets the stream to use for reading the central dir */
 
-int32_t mz_zip_get_cd_mem_stream(void *handle, void **cd_mem_stream);
+MZ_EXPORT int32_t mz_zip_get_cd_mem_stream(void *handle, void **cd_mem_stream);
 /* Get a pointer to the stream used to store the central dir in memory */
 
-int32_t mz_zip_set_number_entry(void *handle, uint64_t number_entry);
+MZ_EXPORT int32_t mz_zip_set_number_entry(void *handle, uint64_t number_entry);
 /* Sets the total number of entries */
 
-int32_t mz_zip_get_number_entry(void *handle, uint64_t *number_entry);
+MZ_EXPORT int32_t mz_zip_get_number_entry(void *handle, uint64_t *number_entry);
 /* Get the total number of entries */
 
-int32_t mz_zip_set_disk_number_with_cd(void *handle, uint32_t disk_number_with_cd);
+MZ_EXPORT int32_t mz_zip_set_disk_number_with_cd(void *handle, uint32_t disk_number_with_cd);
 /* Sets the disk number containing the central directory record */
 
-int32_t mz_zip_get_disk_number_with_cd(void *handle, uint32_t *disk_number_with_cd);
+MZ_EXPORT int32_t mz_zip_get_disk_number_with_cd(void *handle, uint32_t *disk_number_with_cd);
 /* Get the disk number containing the central directory record */
 
 /***************************************************************************/
 
-int32_t mz_zip_entry_is_open(void *handle);
+MZ_EXPORT int32_t mz_zip_entry_is_open(void *handle);
 /* Check to see if entry is open for read/write */
 
-int32_t mz_zip_entry_read_open(void *handle, uint8_t raw, const char *password);
+MZ_EXPORT int32_t mz_zip_entry_read_open(void *handle, uint8_t raw, const char *password);
 /* Open for reading the current file in the zip file */
 
-int32_t mz_zip_entry_read(void *handle, void *buf, int32_t len);
+MZ_EXPORT int32_t mz_zip_entry_read(void *handle, void *buf, int32_t len);
 /* Read bytes from the current file in the zip file */
 
-int32_t mz_zip_entry_read_close(void *handle, uint32_t *crc32, int64_t *compressed_size, int64_t *uncompressed_size);
+MZ_EXPORT int32_t mz_zip_entry_read_close(void *handle, uint32_t *crc32, int64_t *compressed_size,
+                                          int64_t *uncompressed_size);
 /* Close the current file for reading and get data descriptor values */
 
-int32_t mz_zip_entry_write_open(void *handle, const mz_zip_file *file_info, int16_t compress_level, uint8_t raw,
-                                const char *password);
+MZ_EXPORT int32_t mz_zip_entry_write_open(void *handle, const mz_zip_file *file_info, int16_t compress_level,
+                                          uint8_t raw, const char *password);
 /* Open for writing the current file in the zip file */
 
-int32_t mz_zip_entry_write(void *handle, const void *buf, int32_t len);
+MZ_EXPORT int32_t mz_zip_entry_write(void *handle, const void *buf, int32_t len);
 /* Write bytes from the current file in the zip file */
 
-int32_t mz_zip_entry_write_close(void *handle, uint32_t crc32, int64_t compressed_size, int64_t uncompressed_size);
+MZ_EXPORT int32_t mz_zip_entry_write_close(void *handle, uint32_t crc32, int64_t compressed_size,
+                                           int64_t uncompressed_size);
 /* Close the current file for writing and set data descriptor values */
 
-int32_t mz_zip_entry_seek_local_header(void *handle);
+MZ_EXPORT int32_t mz_zip_entry_seek_local_header(void *handle);
 /* Seeks to the local header for the entry */
 
-int32_t mz_zip_entry_get_compress_stream(void *handle, void **compress_stream);
+MZ_EXPORT int32_t mz_zip_entry_get_compress_stream(void *handle, void **compress_stream);
 /* Get a pointer to the compression stream used for the current entry */
 
-int32_t mz_zip_entry_close_raw(void *handle, int64_t uncompressed_size, uint32_t crc32);
+MZ_EXPORT int32_t mz_zip_entry_close_raw(void *handle, int64_t uncompressed_size, uint32_t crc32);
 /* Close the current file in the zip file where raw is compressed data */
 
-int32_t mz_zip_entry_close(void *handle);
+MZ_EXPORT int32_t mz_zip_entry_close(void *handle);
 /* Close the current file in the zip file */
 
 /***************************************************************************/
 
-int32_t mz_zip_entry_is_dir(void *handle);
+MZ_EXPORT int32_t mz_zip_entry_is_dir(void *handle);
 /* Checks to see if the entry is a directory */
 
-int32_t mz_zip_entry_is_symlink(void *handle);
+MZ_EXPORT int32_t mz_zip_entry_is_symlink(void *handle);
 /* Checks to see if the entry is a symbolic link */
 
-int32_t mz_zip_entry_get_info(void *handle, mz_zip_file **file_info);
+MZ_EXPORT int32_t mz_zip_entry_get_info(void *handle, mz_zip_file **file_info);
 /* Get info about the current file, only valid while current entry is open */
 
-int32_t mz_zip_entry_get_local_info(void *handle, mz_zip_file **local_file_info);
+MZ_EXPORT int32_t mz_zip_entry_get_local_info(void *handle, mz_zip_file **local_file_info);
 /* Get local info about the current file, only valid while current entry is being read */
 
-int32_t mz_zip_entry_set_extrafield(void *handle, const uint8_t *extrafield, uint16_t extrafield_size);
+MZ_EXPORT int32_t mz_zip_entry_set_extrafield(void *handle, const uint8_t *extrafield, uint16_t extrafield_size);
 /* Sets or updates the extra field for the entry to be used before writing cd */
 
-int64_t mz_zip_get_entry(void *handle);
+MZ_EXPORT int64_t mz_zip_get_entry(void *handle);
 /* Return offset of the current entry in the zip file */
 
-int32_t mz_zip_goto_entry(void *handle, int64_t cd_pos);
+MZ_EXPORT int32_t mz_zip_goto_entry(void *handle, int64_t cd_pos);
 /* Go to specified entry in the zip file */
 
-int32_t mz_zip_goto_first_entry(void *handle);
+MZ_EXPORT int32_t mz_zip_goto_first_entry(void *handle);
 /* Go to the first entry in the zip file */
 
-int32_t mz_zip_goto_next_entry(void *handle);
+MZ_EXPORT int32_t mz_zip_goto_next_entry(void *handle);
 /* Go to the next entry in the zip file or MZ_END_OF_LIST if reaching the end */
 
-int32_t mz_zip_locate_entry(void *handle, const char *filename, uint8_t ignore_case);
+MZ_EXPORT int32_t mz_zip_locate_entry(void *handle, const char *filename, uint8_t ignore_case);
 /* Locate the file with the specified name in the zip file or MZ_END_LIST if not found */
 
-int32_t mz_zip_locate_first_entry(void *handle, void *userdata, mz_zip_locate_entry_cb cb);
+MZ_EXPORT int32_t mz_zip_locate_first_entry(void *handle, void *userdata, mz_zip_locate_entry_cb cb);
 /* Locate the first matching entry based on a match callback */
 
-int32_t mz_zip_locate_next_entry(void *handle, void *userdata, mz_zip_locate_entry_cb cb);
+MZ_EXPORT int32_t mz_zip_locate_next_entry(void *handle, void *userdata, mz_zip_locate_entry_cb cb);
 /* Locate the next matching entry based on a match callback */
 
 /***************************************************************************/
 
-int32_t mz_zip_attrib_is_dir(uint32_t attrib, int32_t version_madeby);
+MZ_EXPORT int32_t mz_zip_attrib_is_dir(uint32_t attrib, int32_t version_madeby);
 /* Checks to see if the attribute is a directory based on platform */
 
-int32_t mz_zip_attrib_is_symlink(uint32_t attrib, int32_t version_madeby);
+MZ_EXPORT int32_t mz_zip_attrib_is_symlink(uint32_t attrib, int32_t version_madeby);
 /* Checks to see if the attribute is a symbolic link based on platform */
 
-int32_t mz_zip_attrib_convert(uint8_t src_sys, uint32_t src_attrib, uint8_t target_sys, uint32_t *target_attrib);
+MZ_EXPORT int32_t mz_zip_attrib_convert(uint8_t src_sys, uint32_t src_attrib, uint8_t target_sys,
+                                        uint32_t *target_attrib);
 /* Converts file attributes from one host system to another */
 
-int32_t mz_zip_attrib_posix_to_win32(uint32_t posix_attrib, uint32_t *win32_attrib);
+MZ_EXPORT int32_t mz_zip_attrib_posix_to_win32(uint32_t posix_attrib, uint32_t *win32_attrib);
 /* Converts posix file attributes to win32 file attributes */
 
-int32_t mz_zip_attrib_win32_to_posix(uint32_t win32_attrib, uint32_t *posix_attrib);
+MZ_EXPORT int32_t mz_zip_attrib_win32_to_posix(uint32_t win32_attrib, uint32_t *posix_attrib);
 /* Converts win32 file attributes to posix file attributes */
 
 /***************************************************************************/
 
-int32_t mz_zip_extrafield_find(void *stream, uint16_t type, int32_t max_seek, uint16_t *length);
+MZ_EXPORT int32_t mz_zip_extrafield_find(void *stream, uint16_t type, int32_t max_seek, uint16_t *length);
 /* Seeks to extra field by its type and returns its length */
 
-int32_t mz_zip_extrafield_contains(const uint8_t *extrafield, int32_t extrafield_size, uint16_t type, uint16_t *length);
+MZ_EXPORT int32_t mz_zip_extrafield_contains(const uint8_t *extrafield, int32_t extrafield_size, uint16_t type,
+                                             uint16_t *length);
 /* Gets whether an extrafield exists and its size */
 
-int32_t mz_zip_extrafield_read(void *stream, uint16_t *type, uint16_t *length);
+MZ_EXPORT int32_t mz_zip_extrafield_read(void *stream, uint16_t *type, uint16_t *length);
 /* Reads an extrafield header from a stream */
 
-int32_t mz_zip_extrafield_write(void *stream, uint16_t type, uint16_t length);
+MZ_EXPORT int32_t mz_zip_extrafield_write(void *stream, uint16_t type, uint16_t length);
 /* Writes an extrafield header to a stream */
 
 /***************************************************************************/
 
-int32_t mz_zip_dosdate_to_tm(uint64_t dos_date, struct tm *ptm);
+MZ_EXPORT int32_t mz_zip_dosdate_to_tm(uint64_t dos_date, struct tm *ptm);
 /* Convert dos date/time format to struct tm */
 
-time_t mz_zip_dosdate_to_time_t(uint64_t dos_date);
+MZ_EXPORT time_t mz_zip_dosdate_to_time_t(uint64_t dos_date);
 /* Convert dos date/time format to time_t */
 
-time_t mz_zip_tm_to_time_t(struct tm *ptm);
+MZ_EXPORT time_t mz_zip_tm_to_time_t(struct tm *ptm);
 /* Convert year-1900 indexed time struct to time_t */
 
-int32_t mz_zip_time_t_to_tm(time_t unix_time, struct tm *ptm);
+MZ_EXPORT int32_t mz_zip_time_t_to_tm(time_t unix_time, struct tm *ptm);
 /* Convert time_t to time struct */
 
-uint32_t mz_zip_time_t_to_dos_date(time_t unix_time);
+MZ_EXPORT uint32_t mz_zip_time_t_to_dos_date(time_t unix_time);
 /* Convert time_t to dos date/time format */
 
-uint32_t mz_zip_tm_to_dosdate(const struct tm *ptm);
+MZ_EXPORT uint32_t mz_zip_tm_to_dosdate(const struct tm *ptm);
 /* Convert struct tm to dos date/time format */
 
-int32_t mz_zip_ntfs_to_unix_time(uint64_t ntfs_time, time_t *unix_time);
+MZ_EXPORT int32_t mz_zip_ntfs_to_unix_time(uint64_t ntfs_time, time_t *unix_time);
 /* Convert ntfs time to unix time */
 
-int32_t mz_zip_unix_to_ntfs_time(time_t unix_time, uint64_t *ntfs_time);
+MZ_EXPORT int32_t mz_zip_unix_to_ntfs_time(time_t unix_time, uint64_t *ntfs_time);
 /* Convert unix time to ntfs time */
 
 /***************************************************************************/
 
-int32_t mz_zip_path_compare(const char *path1, const char *path2, uint8_t ignore_case);
+MZ_EXPORT int32_t mz_zip_path_compare(const char *path1, const char *path2, uint8_t ignore_case);
 /* Compare two paths without regard to slashes */
 
 /***************************************************************************/
 
-const char *mz_zip_get_compression_method_string(int32_t compression_method);
+MZ_EXPORT const char *mz_zip_get_compression_method_string(int32_t compression_method);
 /* Gets a string representing the compression method */
 
 /***************************************************************************/

--- a/mz_zip_rw.h
+++ b/mz_zip_rw.h
@@ -25,129 +25,129 @@ typedef int32_t (*mz_zip_reader_entry_cb)(void *handle, void *userdata, mz_zip_f
 
 /***************************************************************************/
 
-int32_t mz_zip_reader_is_open(void *handle);
+MZ_EXPORT int32_t mz_zip_reader_is_open(void *handle);
 /* Checks to see if the zip file is open */
 
-int32_t mz_zip_reader_open(void *handle, void *stream);
+MZ_EXPORT int32_t mz_zip_reader_open(void *handle, void *stream);
 /* Opens zip file from stream */
 
-int32_t mz_zip_reader_open_file(void *handle, const char *path);
+MZ_EXPORT int32_t mz_zip_reader_open_file(void *handle, const char *path);
 /* Opens zip file from a file path */
 
-int32_t mz_zip_reader_open_file_in_memory(void *handle, const char *path);
+MZ_EXPORT int32_t mz_zip_reader_open_file_in_memory(void *handle, const char *path);
 /* Opens zip file from a file path into memory for faster access */
 
-int32_t mz_zip_reader_open_buffer(void *handle, const uint8_t *buf, int32_t len, uint8_t copy);
+MZ_EXPORT int32_t mz_zip_reader_open_buffer(void *handle, const uint8_t *buf, int32_t len, uint8_t copy);
 /* Opens zip file from memory buffer */
 
-int32_t mz_zip_reader_close(void *handle);
+MZ_EXPORT int32_t mz_zip_reader_close(void *handle);
 /* Closes the zip file */
 
 /***************************************************************************/
 
-int32_t mz_zip_reader_unzip_cd(void *handle);
+MZ_EXPORT int32_t mz_zip_reader_unzip_cd(void *handle);
 /* Unzip the central directory */
 
 /***************************************************************************/
 
-int32_t mz_zip_reader_goto_first_entry(void *handle);
+MZ_EXPORT int32_t mz_zip_reader_goto_first_entry(void *handle);
 /* Goto the first entry in the zip file that matches the pattern */
 
-int32_t mz_zip_reader_goto_next_entry(void *handle);
+MZ_EXPORT int32_t mz_zip_reader_goto_next_entry(void *handle);
 /* Goto the next entry in the zip file that matches the pattern */
 
-int32_t mz_zip_reader_locate_entry(void *handle, const char *filename, uint8_t ignore_case);
+MZ_EXPORT int32_t mz_zip_reader_locate_entry(void *handle, const char *filename, uint8_t ignore_case);
 /* Locates an entry by filename */
 
-int32_t mz_zip_reader_entry_open(void *handle);
+MZ_EXPORT int32_t mz_zip_reader_entry_open(void *handle);
 /* Opens an entry for reading */
 
-int32_t mz_zip_reader_entry_close(void *handle);
+MZ_EXPORT int32_t mz_zip_reader_entry_close(void *handle);
 /* Closes an entry */
 
-int32_t mz_zip_reader_entry_read(void *handle, void *buf, int32_t len);
+MZ_EXPORT int32_t mz_zip_reader_entry_read(void *handle, void *buf, int32_t len);
 /* Reads an entry after being opened */
 
-int32_t mz_zip_reader_entry_get_hash(void *handle, uint16_t algorithm, uint8_t *digest, int32_t digest_size);
+MZ_EXPORT int32_t mz_zip_reader_entry_get_hash(void *handle, uint16_t algorithm, uint8_t *digest, int32_t digest_size);
 /* Gets a hash algorithm from the entry's extra field */
 
-int32_t mz_zip_reader_entry_get_first_hash(void *handle, uint16_t *algorithm, uint16_t *digest_size);
+MZ_EXPORT int32_t mz_zip_reader_entry_get_first_hash(void *handle, uint16_t *algorithm, uint16_t *digest_size);
 /* Gets the most secure hash algorithm from the entry's extra field */
 
-int32_t mz_zip_reader_entry_get_info(void *handle, mz_zip_file **file_info);
+MZ_EXPORT int32_t mz_zip_reader_entry_get_info(void *handle, mz_zip_file **file_info);
 /* Gets the current entry file info */
 
-int32_t mz_zip_reader_entry_is_dir(void *handle);
+MZ_EXPORT int32_t mz_zip_reader_entry_is_dir(void *handle);
 /* Gets the current entry is a directory */
 
-int32_t mz_zip_reader_entry_save(void *handle, void *stream, mz_stream_write_cb write_cb);
+MZ_EXPORT int32_t mz_zip_reader_entry_save(void *handle, void *stream, mz_stream_write_cb write_cb);
 /* Save the current entry to a stream */
 
-int32_t mz_zip_reader_entry_save_process(void *handle, void *stream, mz_stream_write_cb write_cb);
+MZ_EXPORT int32_t mz_zip_reader_entry_save_process(void *handle, void *stream, mz_stream_write_cb write_cb);
 /* Saves a portion of the current entry to a stream callback */
 
-int32_t mz_zip_reader_entry_save_file(void *handle, const char *path);
+MZ_EXPORT int32_t mz_zip_reader_entry_save_file(void *handle, const char *path);
 /* Save the current entry to a file */
 
-int32_t mz_zip_reader_entry_save_buffer(void *handle, void *buf, int32_t len);
+MZ_EXPORT int32_t mz_zip_reader_entry_save_buffer(void *handle, void *buf, int32_t len);
 /* Save the current entry to a memory buffer */
 
-int32_t mz_zip_reader_entry_save_buffer_length(void *handle);
+MZ_EXPORT int32_t mz_zip_reader_entry_save_buffer_length(void *handle);
 /* Gets the length of the buffer required to save */
 
 /***************************************************************************/
 
-int32_t mz_zip_reader_save_all(void *handle, const char *destination_dir);
+MZ_EXPORT int32_t mz_zip_reader_save_all(void *handle, const char *destination_dir);
 /* Save all files into a directory */
 
 /***************************************************************************/
 
-void mz_zip_reader_set_pattern(void *handle, const char *pattern, uint8_t ignore_case);
+MZ_EXPORT void mz_zip_reader_set_pattern(void *handle, const char *pattern, uint8_t ignore_case);
 /* Sets the match pattern for entries in the zip file, if null all entries are matched */
 
-void mz_zip_reader_set_password(void *handle, const char *password);
+MZ_EXPORT void mz_zip_reader_set_password(void *handle, const char *password);
 /* Sets the password required for extraction */
 
-void mz_zip_reader_set_raw(void *handle, uint8_t raw);
+MZ_EXPORT void mz_zip_reader_set_raw(void *handle, uint8_t raw);
 /* Sets whether or not it should save the entry raw */
 
-int32_t mz_zip_reader_get_raw(void *handle, uint8_t *raw);
+MZ_EXPORT int32_t mz_zip_reader_get_raw(void *handle, uint8_t *raw);
 /* Gets whether or not it should save the entry raw */
 
-int32_t mz_zip_reader_get_zip_cd(void *handle, uint8_t *zip_cd);
+MZ_EXPORT int32_t mz_zip_reader_get_zip_cd(void *handle, uint8_t *zip_cd);
 /* Gets whether or not the archive has a zipped central directory */
 
-int32_t mz_zip_reader_get_comment(void *handle, const char **comment);
+MZ_EXPORT int32_t mz_zip_reader_get_comment(void *handle, const char **comment);
 /* Gets the comment for the central directory */
 
-int32_t mz_zip_reader_set_recover(void *handle, uint8_t recover);
+MZ_EXPORT int32_t mz_zip_reader_set_recover(void *handle, uint8_t recover);
 /* Sets the ability to recover the central dir by reading local file headers */
 
-void mz_zip_reader_set_encoding(void *handle, int32_t encoding);
+MZ_EXPORT void mz_zip_reader_set_encoding(void *handle, int32_t encoding);
 /* Sets whether or not it should support a special character encoding in zip file names. */
 
-void mz_zip_reader_set_overwrite_cb(void *handle, void *userdata, mz_zip_reader_overwrite_cb cb);
+MZ_EXPORT void mz_zip_reader_set_overwrite_cb(void *handle, void *userdata, mz_zip_reader_overwrite_cb cb);
 /* Callback for what to do when a file is being overwritten */
 
-void mz_zip_reader_set_password_cb(void *handle, void *userdata, mz_zip_reader_password_cb cb);
+MZ_EXPORT void mz_zip_reader_set_password_cb(void *handle, void *userdata, mz_zip_reader_password_cb cb);
 /* Callback for when a password is required and hasn't been set */
 
-void mz_zip_reader_set_progress_cb(void *handle, void *userdata, mz_zip_reader_progress_cb cb);
+MZ_EXPORT void mz_zip_reader_set_progress_cb(void *handle, void *userdata, mz_zip_reader_progress_cb cb);
 /* Callback for extraction progress */
 
-void mz_zip_reader_set_progress_interval(void *handle, uint32_t milliseconds);
+MZ_EXPORT void mz_zip_reader_set_progress_interval(void *handle, uint32_t milliseconds);
 /* Let at least milliseconds pass between calls to progress callback */
 
-void mz_zip_reader_set_entry_cb(void *handle, void *userdata, mz_zip_reader_entry_cb cb);
+MZ_EXPORT void mz_zip_reader_set_entry_cb(void *handle, void *userdata, mz_zip_reader_entry_cb cb);
 /* Callback for zip file entries */
 
-int32_t mz_zip_reader_get_zip_handle(void *handle, void **zip_handle);
+MZ_EXPORT int32_t mz_zip_reader_get_zip_handle(void *handle, void **zip_handle);
 /* Gets the underlying zip instance handle */
 
-void *mz_zip_reader_create(void);
+MZ_EXPORT void *mz_zip_reader_create(void);
 /* Create new instance of zip reader */
 
-void mz_zip_reader_delete(void **handle);
+MZ_EXPORT void mz_zip_reader_delete(void **handle);
 /* Delete instance of zip reader */
 
 /***************************************************************************/
@@ -160,116 +160,116 @@ typedef int32_t (*mz_zip_writer_entry_cb)(void *handle, void *userdata, mz_zip_f
 
 /***************************************************************************/
 
-int32_t mz_zip_writer_is_open(void *handle);
+MZ_EXPORT int32_t mz_zip_writer_is_open(void *handle);
 /* Checks to see if the zip file is open */
 
-int32_t mz_zip_writer_open(void *handle, void *stream, uint8_t append);
+MZ_EXPORT int32_t mz_zip_writer_open(void *handle, void *stream, uint8_t append);
 /* Opens zip file from stream */
 
-int32_t mz_zip_writer_open_file(void *handle, const char *path, int64_t disk_size, uint8_t append);
+MZ_EXPORT int32_t mz_zip_writer_open_file(void *handle, const char *path, int64_t disk_size, uint8_t append);
 /* Opens zip file from a file path */
 
-int32_t mz_zip_writer_open_file_in_memory(void *handle, const char *path);
+MZ_EXPORT int32_t mz_zip_writer_open_file_in_memory(void *handle, const char *path);
 /* Opens zip file from a file path into memory for faster access */
 
-int32_t mz_zip_writer_close(void *handle);
+MZ_EXPORT int32_t mz_zip_writer_close(void *handle);
 /* Closes the zip file */
 
 /***************************************************************************/
 
-int32_t mz_zip_writer_entry_open(void *handle, mz_zip_file *file_info);
+MZ_EXPORT int32_t mz_zip_writer_entry_open(void *handle, mz_zip_file *file_info);
 /* Opens an entry in the zip file for writing */
 
-int32_t mz_zip_writer_entry_close(void *handle);
+MZ_EXPORT int32_t mz_zip_writer_entry_close(void *handle);
 /* Closes entry in zip file */
 
-int32_t mz_zip_writer_entry_write(void *handle, const void *buf, int32_t len);
+MZ_EXPORT int32_t mz_zip_writer_entry_write(void *handle, const void *buf, int32_t len);
 /* Writes data into entry for zip */
 
 /***************************************************************************/
 
-int32_t mz_zip_writer_add(void *handle, void *stream, mz_stream_read_cb read_cb);
+MZ_EXPORT int32_t mz_zip_writer_add(void *handle, void *stream, mz_stream_read_cb read_cb);
 /* Writes all data to the currently open entry in the zip */
 
-int32_t mz_zip_writer_add_process(void *handle, void *stream, mz_stream_read_cb read_cb);
+MZ_EXPORT int32_t mz_zip_writer_add_process(void *handle, void *stream, mz_stream_read_cb read_cb);
 /* Writes a portion of data to the currently open entry in the zip */
 
-int32_t mz_zip_writer_add_info(void *handle, void *stream, mz_stream_read_cb read_cb, mz_zip_file *file_info);
+MZ_EXPORT int32_t mz_zip_writer_add_info(void *handle, void *stream, mz_stream_read_cb read_cb, mz_zip_file *file_info);
 /* Adds an entry to the zip based on the info */
 
-int32_t mz_zip_writer_add_buffer(void *handle, const void *buf, int32_t len, mz_zip_file *file_info);
+MZ_EXPORT int32_t mz_zip_writer_add_buffer(void *handle, const void *buf, int32_t len, mz_zip_file *file_info);
 /* Adds an entry to the zip with a memory buffer */
 
-int32_t mz_zip_writer_add_file(void *handle, const char *path, const char *filename_in_zip);
+MZ_EXPORT int32_t mz_zip_writer_add_file(void *handle, const char *path, const char *filename_in_zip);
 /* Adds an entry to the zip from a file */
 
-int32_t mz_zip_writer_add_path(void *handle, const char *path, const char *root_path, uint8_t include_path,
-                               uint8_t recursive);
+MZ_EXPORT int32_t mz_zip_writer_add_path(void *handle, const char *path, const char *root_path, uint8_t include_path,
+                                         uint8_t recursive);
 /* Enumerates a directory or pattern and adds entries to the zip */
 
-int32_t mz_zip_writer_copy_from_reader(void *handle, void *reader);
+MZ_EXPORT int32_t mz_zip_writer_copy_from_reader(void *handle, void *reader);
 /* Adds an entry from a zip reader instance */
 
 /***************************************************************************/
 
-void mz_zip_writer_set_password(void *handle, const char *password);
+MZ_EXPORT void mz_zip_writer_set_password(void *handle, const char *password);
 /* Password to use for encrypting files in the zip */
 
-void mz_zip_writer_set_comment(void *handle, const char *comment);
+MZ_EXPORT void mz_zip_writer_set_comment(void *handle, const char *comment);
 /* Comment to use for the archive */
 
-void mz_zip_writer_set_raw(void *handle, uint8_t raw);
+MZ_EXPORT void mz_zip_writer_set_raw(void *handle, uint8_t raw);
 /* Sets whether or not we should write the entry raw */
 
-int32_t mz_zip_writer_get_raw(void *handle, uint8_t *raw);
+MZ_EXPORT int32_t mz_zip_writer_get_raw(void *handle, uint8_t *raw);
 /* Gets whether or not we should write the entry raw */
 
-void mz_zip_writer_set_aes(void *handle, uint8_t aes);
+MZ_EXPORT void mz_zip_writer_set_aes(void *handle, uint8_t aes);
 /* Use aes encryption when adding files in zip */
 
-void mz_zip_writer_set_compress_method(void *handle, uint16_t compress_method);
+MZ_EXPORT void mz_zip_writer_set_compress_method(void *handle, uint16_t compress_method);
 /* Sets the compression method when adding files in zip */
 
-void mz_zip_writer_set_compress_level(void *handle, int16_t compress_level);
+MZ_EXPORT void mz_zip_writer_set_compress_level(void *handle, int16_t compress_level);
 /* Sets the compression level when adding files in zip */
 
-void mz_zip_writer_set_follow_links(void *handle, uint8_t follow_links);
+MZ_EXPORT void mz_zip_writer_set_follow_links(void *handle, uint8_t follow_links);
 /* Follow symbolic links when traversing directories and files to add */
 
-int32_t mz_zip_writer_get_follow_links(void *handle, uint8_t *follow_links);
+MZ_EXPORT int32_t mz_zip_writer_get_follow_links(void *handle, uint8_t *follow_links);
 /* Gets whether to follow symbolic links when traversing directories and files to add */
 
-void mz_zip_writer_set_store_links(void *handle, uint8_t store_links);
+MZ_EXPORT void mz_zip_writer_set_store_links(void *handle, uint8_t store_links);
 /* Store symbolic links in zip file */
 
-void mz_zip_writer_set_zip_cd(void *handle, uint8_t zip_cd);
+MZ_EXPORT void mz_zip_writer_set_zip_cd(void *handle, uint8_t zip_cd);
 /* Sets whether or not central directory should be zipped */
 
-int32_t mz_zip_writer_set_certificate(void *handle, const char *cert_path, const char *cert_pwd);
+MZ_EXPORT int32_t mz_zip_writer_set_certificate(void *handle, const char *cert_path, const char *cert_pwd);
 /* Sets the certificate and timestamp url to use for signing when adding files in zip */
 
-void mz_zip_writer_set_overwrite_cb(void *handle, void *userdata, mz_zip_writer_overwrite_cb cb);
+MZ_EXPORT void mz_zip_writer_set_overwrite_cb(void *handle, void *userdata, mz_zip_writer_overwrite_cb cb);
 /* Callback for what to do when zip file already exists */
 
-void mz_zip_writer_set_password_cb(void *handle, void *userdata, mz_zip_writer_password_cb cb);
+MZ_EXPORT void mz_zip_writer_set_password_cb(void *handle, void *userdata, mz_zip_writer_password_cb cb);
 /* Callback for ask if a password is required for adding */
 
-void mz_zip_writer_set_progress_cb(void *handle, void *userdata, mz_zip_writer_progress_cb cb);
+MZ_EXPORT void mz_zip_writer_set_progress_cb(void *handle, void *userdata, mz_zip_writer_progress_cb cb);
 /* Callback for compression progress */
 
-void mz_zip_writer_set_progress_interval(void *handle, uint32_t milliseconds);
+MZ_EXPORT void mz_zip_writer_set_progress_interval(void *handle, uint32_t milliseconds);
 /* Let at least milliseconds pass between calls to progress callback */
 
-void mz_zip_writer_set_entry_cb(void *handle, void *userdata, mz_zip_writer_entry_cb cb);
+MZ_EXPORT void mz_zip_writer_set_entry_cb(void *handle, void *userdata, mz_zip_writer_entry_cb cb);
 /* Callback for zip file entries */
 
-int32_t mz_zip_writer_get_zip_handle(void *handle, void **zip_handle);
+MZ_EXPORT int32_t mz_zip_writer_get_zip_handle(void *handle, void **zip_handle);
 /* Gets the underlying zip handle */
 
-void *mz_zip_writer_create(void);
+MZ_EXPORT void *mz_zip_writer_create(void);
 /* Create new instance of zip writer */
 
-void mz_zip_writer_delete(void **handle);
+MZ_EXPORT void mz_zip_writer_delete(void **handle);
 /* Delete instance of zip writer */
 
 /***************************************************************************/


### PR DESCRIPTION
- Update MZ_EXPORT macro to use visibility attributes on non-Windows
- Add MZ_EXPORT to all public function declarations in headers
- Set C_VISIBILITY_PRESET hidden on minizip target
- Fix ZEXPORT in compat layer to properly export symbols
- Add missing ZEXPORT on compat API functions

Resolves #475