### PR TITLE
Fix comment leak in mz_zip_read_cd()

### DIFF
--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1001,6 +1001,7 @@ static int32_t mz_zip_read_cd(void *handle) {
         if (err == MZ_OK)
             err = mz_stream_read_uint16(zip->stream, &comment_size);
         if ((err == MZ_OK) && (comment_size > 0)) {
+            free(zip->comment);
             zip->comment = (char *)malloc(comment_size + 1);
             if (zip->comment) {
                 comment_read = mz_stream_read(zip->stream, zip->comment, comment_size);

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1010,6 +1010,11 @@ static int32_t mz_zip_read_cd(void *handle) {
                     comment_read = 0;
                 zip->comment[comment_read] = 0;
             }
+        } else if (err == MZ_OK) {
+            /* No comment in this archive; clear any stale comment from a
+               previous mz_zip_read_cd() call on the same handle */
+            free(zip->comment);
+            zip->comment = NULL;
         }
 
         if ((err == MZ_OK) && ((number_entry_cd == UINT16_MAX) || (zip->cd_offset == UINT32_MAX))) {

--- a/mz_zip.c
+++ b/mz_zip.c
@@ -1011,8 +1011,6 @@ static int32_t mz_zip_read_cd(void *handle) {
                 zip->comment[comment_read] = 0;
             }
         } else if (err == MZ_OK) {
-            /* No comment in this archive; clear any stale comment from a
-               previous mz_zip_read_cd() call on the same handle */
             free(zip->comment);
             zip->comment = NULL;
         }


### PR DESCRIPTION
`zip->comment` is overwritten with a newly `malloc`'d buffer without
freeing any comment that may already be set on the handle. This leaks
memory when `mz_zip_read_cd()` is invoked more than once on the same
zip handle (e.g. a repeated `mz_zip_open()` call), since the pointer
to the previous allocation is discarded.

Fix : free the existing `zip->comment` before allocating a new one.

This is a minimal, one-line addition with no behavioral change on the
first-open path (where `zip->comment` is already `NULL`).