### PR TITLE
Fix compression test error propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -919,6 +919,9 @@ if(MZ_BUILD_TESTS AND MZ_BUILD_UNIT_TESTS)
             list(APPEND COMPRESS_METHOD_ARGS "-t")
         endif()
         list(LENGTH COMPRESS_METHOD_NAMES COMPRESS_METHOD_COUNT)
+        if(COMPRESS_METHOD_COUNT EQUAL 0)
+            return()
+        endif()
         math(EXPR COMPRESS_METHOD_COUNT "${COMPRESS_METHOD_COUNT}-1")
         foreach(INDEX RANGE ${COMPRESS_METHOD_COUNT})
             list(GET COMPRESS_METHOD_NAMES ${INDEX} COMPRESS_METHOD_NAME)
@@ -932,7 +935,7 @@ if(MZ_BUILD_TESTS AND MZ_BUILD_UNIT_TESTS)
             add_test(NAME ${COMPRESS_METHOD_NAME}-zip-${EXTRA_NAME}
                      COMMAND minizip_cli ${COMPRESS_METHOD_ARG} -o ${EXTRA_ARGS}
                         ${COMPRESS_METHOD_PATH}
-                        test.c test.h empty.txt random.bin uniform.bin fuzz
+                        empty.txt random.bin uniform.bin fuzz
                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
             add_test(NAME ${COMPRESS_METHOD_NAME}-list-${EXTRA_NAME}
                      COMMAND minizip_cli -l ${EXTRA_ARGS} ${COMPRESS_METHOD_PATH}
@@ -954,7 +957,7 @@ if(MZ_BUILD_TESTS AND MZ_BUILD_UNIT_TESTS)
                             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
             endif()
             add_test(NAME ${COMPRESS_METHOD_NAME}-erase-${EXTRA_NAME}
-                    COMMAND minizip_cli -o -e ${COMPRESS_METHOD_PATH} test.c test.h
+                    COMMAND minizip_cli -o -e ${COMPRESS_METHOD_PATH} empty.txt random.bin
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
             if(NOT MZ_COMPRESS_ONLY)
                 add_test(NAME ${COMPRESS_METHOD_NAME}-erase-unzip-${EXTRA_NAME}

--- a/minizip.c
+++ b/minizip.c
@@ -299,8 +299,10 @@ int32_t minizip_add(const char *path, const char *password, minizip_opt *options
 
             /* Add file system path to archive */
             err = mz_zip_writer_add_path(writer, filename_in_zip, NULL, options->include_path, 1);
-            if (err != MZ_OK)
+            if (err != MZ_OK) {
                 printf("Error %" PRId32 " adding path to archive %s\n", err, filename_in_zip);
+                break;
+            }
         }
     } else {
         printf("Error %" PRId32 " opening archive for writing\n", err);
@@ -309,7 +311,8 @@ int32_t minizip_add(const char *path, const char *password, minizip_opt *options
     err_close = mz_zip_writer_close(writer);
     if (err_close != MZ_OK) {
         printf("Error %" PRId32 " closing archive for writing %s\n", err_close, path);
-        err = err_close;
+        if (err == MZ_OK)
+            err = err_close;
     }
 
     mz_zip_writer_delete(&writer);


### PR DESCRIPTION
## Summary

- Stop archive creation at the first input failure so the CLI preserves and returns the original error.
- Update the compression CTest fixtures to use files that exist and erase entries that were actually archived.
- Skip compression test generation when no compression methods are available.

## Details

The compression tests referenced `test.c` and `test.h`, which do not exist in the test working directory. `minizip_add()` reported those failures but continued processing later inputs. A later successful addition could overwrite the earlier error, causing the command to return success after a partial failure and masking the invalid test fixtures.

This change makes `minizip_add()` stop at the first failed path so callers and CTest receive the original non-zero result. Archive close failures are still reported, but no longer replace an earlier input error. The test inputs now use existing fixtures, and the erase tests remove entries that were actually added to the archive.

CTest generation also returns early for variants that have no available compression method, instead of creating duplicate `NOTFOUND-*` tests.