### PR TITLE
Offline compilation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,27 @@ check_function_exists(readlink HAVE_READLINK)
 configure_file(mz_config.h.cmakein ${CMAKE_CURRENT_BINARY_DIR}/mz_config.h @ONLY NEWLINE_STYLE UNIX)
 list(APPEND MINIZIP_HDR ${CMAKE_CURRENT_BINARY_DIR}/mz_config.h)
 
+#
+# Check whether a sanitizer was requested
+#
+message(STATUS "Checking for sanitizer option")
+
+string(TOLOWER "${MZ_SANITIZER}" MZ_SANITIZER)
+if(NOT MZ_SANITIZER)
+    message(STATUS " sanitizer not enabled")
+elseif(MZ_SANITIZER STREQUAL "address")
+    add_address_sanitizer()
+elseif(MZ_SANITIZER STREQUAL "memory")
+    add_memory_sanitizer()
+elseif(MZ_SANITIZER STREQUAL "thread")
+    add_thread_sanitizer()
+elseif(MZ_SANITIZER STREQUAL "undefined")
+    add_undefined_sanitizer()
+else()
+    message(FATAL_ERROR "Unknown MZ_SANITIZER option: '${MZ_SANITIZER}'\n"
+                        "MZ_SANITIZER must be one of: 'memory', 'address', 'undefined', 'thread'")
+endif()
+
 if(MZ_LIBCOMP)
     if(APPLE)
         # Use Apple libcompression
@@ -191,6 +212,9 @@ if(MZ_LIBCOMP)
 endif()
 
 if(MZ_ZLIB)
+    set(_zlib_local_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/third_party/zlib")
+    set(_zlib_source_build OFF)
+
     # Check if zlib is present
     if(NOT MZ_FORCE_FETCH_LIBS)
         if (MZ_ZLIB_FLAVOR STREQUAL "zlib-ng" OR MZ_ZLIB_FLAVOR STREQUAL "auto")
@@ -219,11 +243,29 @@ if(MZ_ZLIB)
 
         set(PC_PRIVATE_DEPS "zlib")
         set(ZLIB_COMPAT ON)
-    elseif(MZ_FETCH_LIBS)
+    elseif(EXISTS "${_zlib_local_source_dir}/CMakeLists.txt" AND
+           NOT (MZ_FORCE_FETCH_LIBS OR MZ_FETCH_LIBS))
+        message(STATUS "Using bundled ZLIB from ${_zlib_local_source_dir}")
+
+        set(BUILD_TESTING OFF CACHE BOOL "Build zlib-ng tests" FORCE)
+        set(ZLIB_SOURCE_DIR "${_zlib_local_source_dir}")
+        set(ZLIB_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/zlib-build")
+
+        add_subdirectory("${ZLIB_SOURCE_DIR}" "${ZLIB_BINARY_DIR}" EXCLUDE_FROM_ALL)
+        set(_zlib_source_build ON)
+    elseif(MZ_FETCH_LIBS OR MZ_FORCE_FETCH_LIBS)
         set(BUILD_TESTING OFF CACHE BOOL "Build zlib-ng tests" FORCE)
 
         clone_repo(zlib https://github.com/zlib-ng/zlib-ng stable)
 
+        set(_zlib_source_build ON)
+    else()
+        message(STATUS "ZLIB library not found")
+
+        set(MZ_ZLIB OFF)
+    endif()
+
+    if(_zlib_source_build)
         list(APPEND MINIZIP_INC ${ZLIB_SOURCE_DIR})
         list(APPEND MINIZIP_INC ${ZLIB_BINARY_DIR})
 
@@ -242,10 +284,6 @@ if(MZ_ZLIB)
             list(APPEND MINIZIP_DEP zlib)
             list(APPEND MINIZIP_LIB_PUBLIC zlib)
         endif()
-    else()
-        message(STATUS "ZLIB library not found")
-
-        set(MZ_ZLIB OFF)
     endif()
 
     if(MZ_ZLIB)
@@ -273,6 +311,9 @@ if(MZ_ZLIB)
 endif()
 
 if(MZ_BZIP2)
+    set(_bzip2_local_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/third_party/bzip2")
+    set(_bzip2_source_build OFF)
+
     # Check if bzip2 is present
     if(NOT MZ_FORCE_FETCH_LIBS)
         find_package(BZip2 QUIET)
@@ -284,9 +325,22 @@ if(MZ_BZIP2)
         list(APPEND MINIZIP_LIB BZip2::BZip2)
 
         set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lbz2")
-    elseif(MZ_FETCH_LIBS)
+    elseif(EXISTS "${_bzip2_local_source_dir}/bzlib.h" AND
+           NOT (MZ_FORCE_FETCH_LIBS OR MZ_FETCH_LIBS))
+        message(STATUS "Using bundled BZIP2 from ${_bzip2_local_source_dir}")
+        set(BZIP2_SOURCE_DIR "${_bzip2_local_source_dir}")
+        set(_bzip2_source_build ON)
+    elseif(MZ_FETCH_LIBS OR MZ_FORCE_FETCH_LIBS)
         clone_repo(bzip2 https://sourceware.org/git/bzip2.git master)
 
+        set(_bzip2_source_build ON)
+    else()
+        message(STATUS "BZip2 library not found")
+
+        set(MZ_BZIP2 OFF)
+    endif()
+
+    if(_bzip2_source_build)
         # BZip2 repository does not support cmake so we have to create
         # the bzip2 library ourselves
         set(BZIP2_SRC
@@ -308,10 +362,6 @@ if(MZ_BZIP2)
 
         list(APPEND MINIZIP_DEP bzip2)
         list(APPEND MINIZIP_INC ${BZIP2_SOURCE_DIR})
-    else()
-        message(STATUS "BZip2 library not found")
-
-        set(MZ_BZIP2 OFF)
     endif()
 
     if(MZ_BZIP2)
@@ -325,6 +375,9 @@ if(MZ_BZIP2)
 endif()
 
 if(MZ_LZMA)
+    set(_liblzma_local_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/third_party/liblzma")
+    set(_liblzma_source_build OFF)
+
     # Check if liblzma is present
     if(NOT MZ_FORCE_FETCH_LIBS)
         find_package(LibLZMA QUIET)
@@ -336,19 +389,33 @@ if(MZ_LZMA)
         list(APPEND MINIZIP_LIB LibLZMA::LibLZMA)
 
         set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -llzma")
-    elseif(MZ_FETCH_LIBS)
+    elseif(EXISTS "${_liblzma_local_source_dir}/CMakeLists.txt" AND
+           NOT (MZ_FORCE_FETCH_LIBS OR MZ_FETCH_LIBS))
+        message(STATUS "Using bundled LZMA from ${_liblzma_local_source_dir}")
+
+        set(BUILD_TESTING OFF CACHE BOOL "Build lzma tests" FORCE)
+        set(LIBLZMA_SOURCE_DIR "${_liblzma_local_source_dir}")
+        set(LIBLZMA_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/liblzma-build")
+
+        add_subdirectory("${LIBLZMA_SOURCE_DIR}" "${LIBLZMA_BINARY_DIR}" EXCLUDE_FROM_ALL)
+        set(_liblzma_source_build ON)
+    elseif(MZ_FETCH_LIBS OR MZ_FORCE_FETCH_LIBS)
         set(BUILD_TESTING OFF CACHE BOOL "Build lzma tests" FORCE)
 
         clone_repo(liblzma https://github.com/tukaani-project/xz master)
 
-        list(APPEND MINIZIP_INC ${LIBLZMA_SOURCE_DIR}/src/liblzma/api)
-        list(APPEND MINIZIP_DEP liblzma)
-        # liblzma's exported target references Threads::Threads
-        list(APPEND MINIZIP_DEP_PKG Threads)
+        set(_liblzma_source_build ON)
     else()
         message(STATUS "LibLZMA library not found")
 
         set(MZ_LZMA OFF)
+    endif()
+
+    if(_liblzma_source_build)
+        list(APPEND MINIZIP_INC ${LIBLZMA_SOURCE_DIR}/src/liblzma/api)
+        list(APPEND MINIZIP_DEP liblzma)
+        # liblzma's exported target references Threads::Threads
+        list(APPEND MINIZIP_DEP_PKG Threads)
     endif()
 
     if(MZ_LZMA)
@@ -362,43 +429,56 @@ if(MZ_LZMA)
 endif()
 
 if(MZ_PPMD)
-    message(STATUS "Using PPMD")
+    set(_ppmd_local_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/third_party/ppmd")
 
-    # PPMd version number below should match value in ppmd-dependabot.yml
-    clone_repo(ppmd https://github.com/ip7z/7zip "26.02")
+    if(EXISTS "${_ppmd_local_source_dir}/C/7zVersion.h" AND
+       NOT (MZ_FORCE_FETCH_LIBS OR MZ_FETCH_LIBS))
+        message(STATUS "Using bundled PPMD from ${_ppmd_local_source_dir}")
+        set(PPMD_SOURCE_DIR "${_ppmd_local_source_dir}")
+    elseif(MZ_FETCH_LIBS OR MZ_FORCE_FETCH_LIBS)
+        # PPMd version number below should match value in ppmd-dependabot.yml
+        clone_repo(ppmd https://github.com/ip7z/7zip "26.02")
+    else()
+        message(STATUS "PPMD source not found")
+        set(MZ_PPMD OFF)
+    endif()
 
-    # get the 7zip/PPMd version number
-    file(READ "${PPMD_SOURCE_DIR}/C/7zVersion.h" version)
-    string(REGEX MATCH "MY_VERSION_NUMBERS \"([0-9]*\.[0-9]*)\"" _ ${version})
-    set(7ZIP_VERSION_NUMBER ${CMAKE_MATCH_1})
-    message(STATUS "  Found 7Zip/PPMd ${7ZIP_VERSION_NUMBER}")
+    if(MZ_PPMD)
+        # get the 7zip/PPMd version number
+        file(READ "${PPMD_SOURCE_DIR}/C/7zVersion.h" version)
+        string(REGEX MATCH "MY_VERSION_NUMBERS \"([0-9]*\.[0-9]*)\"" _ ${version})
+        set(7ZIP_VERSION_NUMBER ${CMAKE_MATCH_1})
+        message(STATUS "  Found 7Zip/PPMd ${7ZIP_VERSION_NUMBER}")
 
-    # The PPMd repository does not support cmake so we have to create
-    # a PPMd library ourselves
-    set(PPMD_SRC
-        ${PPMD_SOURCE_DIR}/C/Ppmd8.c
-        ${PPMD_SOURCE_DIR}/C/Ppmd8Dec.c
-        ${PPMD_SOURCE_DIR}/C/Ppmd8Enc.c)
+        # The PPMd repository does not support cmake so we have to create
+        # a PPMd library ourselves
+        set(PPMD_SRC
+            ${PPMD_SOURCE_DIR}/C/Ppmd8.c
+            ${PPMD_SOURCE_DIR}/C/Ppmd8Dec.c
+            ${PPMD_SOURCE_DIR}/C/Ppmd8Enc.c)
 
-    set(PPMD_HDR
-        ${PPMD_SOURCE_DIR}/C/7zTypes.h
-        ${PPMD_SOURCE_DIR}/C/Compiler.h
-        ${PPMD_SOURCE_DIR}/C/CpuArch.h
-        ${PPMD_SOURCE_DIR}/C/Ppmd.h
-        ${PPMD_SOURCE_DIR}/C/Ppmd8.h
-        ${PPMD_SOURCE_DIR}/C/Precomp.h)
+        set(PPMD_HDR
+            ${PPMD_SOURCE_DIR}/C/7zTypes.h
+            ${PPMD_SOURCE_DIR}/C/Compiler.h
+            ${PPMD_SOURCE_DIR}/C/CpuArch.h
+            ${PPMD_SOURCE_DIR}/C/Ppmd.h
+            ${PPMD_SOURCE_DIR}/C/Ppmd8.h
+            ${PPMD_SOURCE_DIR}/C/Precomp.h)
 
-    add_library(ppmd STATIC ${PPMD_SRC} ${PPMD_HDR})
+        add_library(ppmd STATIC ${PPMD_SRC} ${PPMD_HDR})
 
-    list(APPEND MINIZIP_DEP ppmd)
-    list(APPEND MINIZIP_INC ${PPMD_SOURCE_DIR})
+        list(APPEND MINIZIP_DEP ppmd)
+        list(APPEND MINIZIP_INC ${PPMD_SOURCE_DIR})
 
-    list(APPEND MINIZIP_DEF -DHAVE_PPMD)
-    list(APPEND MINIZIP_SRC mz_strm_ppmd.c)
-    list(APPEND MINIZIP_HDR mz_strm_ppmd.h)
+        list(APPEND MINIZIP_DEF -DHAVE_PPMD)
+        list(APPEND MINIZIP_SRC mz_strm_ppmd.c)
+        list(APPEND MINIZIP_HDR mz_strm_ppmd.h)
+    endif()
 endif()
 
 if(MZ_ZSTD)
+    set(_zstd_local_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/third_party/zstd")
+
     # Check if zstd is present
     if(NOT MZ_FORCE_FETCH_LIBS)
         find_package(zstd QUIET CONFIG)
@@ -414,7 +494,23 @@ if(MZ_ZSTD)
         endif()
 
         set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lzstd")
-    elseif(MZ_FETCH_LIBS)
+    elseif(EXISTS "${_zstd_local_source_dir}/build/cmake/CMakeLists.txt" AND
+           NOT (MZ_FORCE_FETCH_LIBS OR MZ_FETCH_LIBS))
+        message(STATUS "Using bundled ZSTD from ${_zstd_local_source_dir}")
+
+        set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "Build zstd programs")
+        set(ZSTD_SOURCE_DIR "${_zstd_local_source_dir}")
+
+        add_subdirectory("${ZSTD_SOURCE_DIR}/build/cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/_deps/zstd-build" EXCLUDE_FROM_ALL)
+
+        list(APPEND MINIZIP_INC ${ZSTD_SOURCE_DIR}/lib)
+        if(NOT DEFINED BUILD_SHARED_LIBS OR NOT ${BUILD_SHARED_LIBS})
+            list(APPEND MINIZIP_DEP libzstd_static)
+        else()
+            list(APPEND MINIZIP_DEP libzstd_shared)
+        endif()
+    elseif(MZ_FETCH_LIBS OR MZ_FORCE_FETCH_LIBS)
         set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "Build zstd programs")
 
         clone_repo(zstd https://github.com/facebook/zstd release build/cmake)
@@ -683,27 +779,6 @@ if(MZ_COMPAT)
     if(MZ_COMPAT_VERSION)
         list(APPEND MINIZIP_DEF -DMZ_COMPAT_VERSION=${MZ_COMPAT_VERSION})
     endif()
-endif()
-
-#
-# Check whether a sanitizer was requested
-#
-message(STATUS "Checking for sanitizer option")
-
-string(TOLOWER "${MZ_SANITIZER}" MZ_SANITIZER)
-if(NOT MZ_SANITIZER)
-    message(STATUS " sanitizer not enabled")
-elseif(MZ_SANITIZER STREQUAL "address")
-    add_address_sanitizer()
-elseif(MZ_SANITIZER STREQUAL "memory")
-    add_memory_sanitizer()
-elseif(MZ_SANITIZER STREQUAL "thread")
-    add_thread_sanitizer()
-elseif(MZ_SANITIZER STREQUAL "undefined")
-    add_undefined_sanitizer()
-else()
-    message(FATAL_ERROR "Unknown MZ_SANITIZER option: '${MZ_SANITIZER}'\n"
-                        "MZ_SANITIZER must be one of: 'memory', 'address', 'undefined', 'thread'")
 endif()
 
 # Set compiler options

--- a/cmake/clone-repo.cmake
+++ b/cmake/clone-repo.cmake
@@ -12,6 +12,12 @@ macro(clone_repo name url tag)
 
     set(_clone_repo_cmake_subdir ${ARGN})
 
+    set(_clone_repo_source_dir_args
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/${name_lower})
+    if(MZ_FORCE_FETCH_LIBS OR MZ_FETCH_LIBS)
+        set(_clone_repo_source_dir_args)
+    endif()
+
     message(STATUS "Fetching ${name} ${${name_upper}_REPOSITORY} ${${name_upper}_TAG}")
 
     # Check for FetchContent cmake support
@@ -27,7 +33,7 @@ macro(clone_repo name url tag)
             FetchContent_Declare(${name}
                 GIT_REPOSITORY ${${name_upper}_REPOSITORY}
                 GIT_TAG ${${name_upper}_TAG}
-                SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/${name_lower})
+                ${_clone_repo_source_dir_args})
 
             FetchContent_GetProperties(${name})
             if(NOT ${name_lower}_POPULATED)
@@ -38,14 +44,14 @@ macro(clone_repo name url tag)
                 FetchContent_Declare(${name}
                     GIT_REPOSITORY ${${name_upper}_REPOSITORY}
                     GIT_TAG ${${name_upper}_TAG}
-                    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/${name_lower}
+                    ${_clone_repo_source_dir_args}
                     SOURCE_SUBDIR ${_clone_repo_cmake_subdir}
                     EXCLUDE_FROM_ALL)
             else()
                 FetchContent_Declare(${name}
                     GIT_REPOSITORY ${${name_upper}_REPOSITORY}
                     GIT_TAG ${${name_upper}_TAG}
-                    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/${name_lower}
+                    ${_clone_repo_source_dir_args}
                     EXCLUDE_FROM_ALL)
             endif()
 


### PR DESCRIPTION
## Summary

- Prefer installed compression libraries unless fetching is explicitly forced.
- Support pre-populated dependency sources under `<source>/third_party` when both fetch options are disabled.
- Keep fetched sources in the CMake build tree when fetching is enabled.

## Motivation

Offline and intranet builds must be able to compile without fetching from external repositories. Users can prepare the required dependency source code under `third_party` ahead of time, then configure and build minizip-ng without outbound network access.

## Why the previous code could not provide an offline build

On the base commit (`bc099de`), the local `third_party` directory was not treated as a reusable source fallback:

- ZLIB, BZIP2, LZMA, and Zstandard only entered `clone_repo()` when `MZ_FETCH_LIBS=ON`. With both fetch options disabled and no system package available, CMake did not inspect the pre-populated source directories and disabled those compression backends.
- PPMd called `clone_repo()` unconditionally. The old `FetchContent_Declare(... SOURCE_DIR <source>/third_party/ppmd)` selected the clone destination; it did not mark existing contents as already populated. CMake therefore still attempted to clone from GitHub even when `MZ_FETCH_LIBS=OFF`.

### Reproduction on the base commit

Tested on WSL2 (Debian 13, GCC 14.2.0, CMake 3.31.6) with all five dependency sources prepared under `<source>/third_party`, system package discovery disabled, both fetch options set to `OFF`, and network proxies pointed at an unreachable local endpoint:

- Configuration reported ZLIB, BZIP2, and LibLZMA as not found, then attempted to clone PPMd from GitHub three times and failed.
- Repeating the test with `MZ_PPMD=OFF` allowed configuration and compilation to finish, but ZLIB, BZIP2, LZMA, and Zstandard were all disabled despite their sources being present. CMake reported `Compression not supported due to missing libraries`.

The previous implementation therefore could not produce a full compression-enabled build from a self-contained source tree with fetching disabled: it either attempted network access for PPMd or silently disabled the other compression backends.

## Source selection by option

| `MZ_FETCH_LIBS` | `MZ_FORCE_FETCH_LIBS` | System package lookup | Dependency source location and behavior | Network fetch |
|---|---|---|---|---|
| `OFF` | `OFF` | Yes | Use the installed package when found; otherwise use pre-populated source from `<source>/third_party/<dependency>` | No. If neither source is available, the corresponding compression method is disabled. |
| `ON` | `OFF` | Yes | Use the installed package when found; otherwise populate source under `<build>/_deps/<dependency>-src` | As needed |
| `OFF` | `ON` | No | Populate source under `<build>/_deps/<dependency>-src` | As needed |
| `ON` | `ON` | No | Populate source under `<build>/_deps/<dependency>-src` | As needed |

PPMd does not have a system-package lookup path, so it uses the pre-populated `third_party` source directly in offline mode and the build-tree source in fetch-enabled modes.

## Pre-populated source directories

| Dependency | Offline/intranet source directory |
|---|---|
| ZLIB / zlib-ng | `<source>/third_party/zlib` |
| BZIP2 | `<source>/third_party/bzip2` |
| LZMA / xz | `<source>/third_party/liblzma` |
| PPMd / 7-Zip | `<source>/third_party/ppmd` |
| Zstandard | `<source>/third_party/zstd` |

## Validation

- Windows: CMake configure and build completed successfully; all 246 CTest tests passed.
- Linux (WSL2, Debian 13, GCC 14.2.0, CMake 3.31.6): with `MZ_FETCH_LIBS=OFF` and `MZ_FORCE_FETCH_LIBS=OFF`, all compression dependencies were resolved from pre-populated `<source>/third_party` sources while system package discovery was disabled and network proxies were invalid. Configure and build completed successfully, and all 246 CTest tests passed.