### PR TITLE
Harden extraction against symlink traversal

### DIFF
--- a/mz_os.c
+++ b/mz_os.c
@@ -296,7 +296,7 @@ int32_t mz_path_get_filename(const char *path, const char **filename) {
 int32_t mz_path_is_symlink_target_safe(const char *link_path, const char *target, const char *base_path) {
     char *combined = NULL;
     char *resolved = NULL;
-    size_t max_path = 1024;
+    size_t max_path = 0;
     size_t base_len = 0;
     size_t parent_len = 0;
     int32_t err = MZ_OK;
@@ -313,6 +313,8 @@ int32_t mz_path_is_symlink_target_safe(const char *link_path, const char *target
     /* Remove trailing slash from base_path for comparison */
     while (base_len > 0 && mz_os_is_dir_separator(base_path[base_len - 1]))
         base_len--;
+
+    max_path = strlen(link_path) + strlen(target) + 2;
 
     combined = (char *)calloc(1, max_path);
     resolved = (char *)calloc(1, max_path);

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -733,8 +733,9 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
         goto save_cleanup;
     }
 
-    /* Check if file exists and ask if we want to overwrite */
-    if (reader->overwrite_cb && mz_os_file_exists(pathwfs) == MZ_OK) {
+    /* Check if a file or symlink exists and ask if we want to overwrite. A dangling symlink is
+       reported absent by stat, so check for the link itself as well. */
+    if (reader->overwrite_cb && (mz_os_file_exists(pathwfs) == MZ_OK || mz_os_is_symlink(pathwfs) == MZ_OK)) {
         err_cb = reader->overwrite_cb(reader, reader->overwrite_userdata, reader->file_info, pathwfs);
         if (err_cb != MZ_OK)
             goto save_cleanup;
@@ -794,6 +795,14 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
         goto save_cleanup;
     }
 
+    /* Remove any symlink still at the output path so file creation writes a new file rather
+       than following the link to a location outside the destination */
+    if (mz_os_is_symlink(pathwfs) == MZ_OK) {
+        err = mz_os_unlink(pathwfs);
+        if (err != MZ_OK)
+            goto save_cleanup;
+    }
+
     /* Create the file on disk so we can save to it */
     stream = mz_stream_os_create();
     if (!stream) {
@@ -801,7 +810,8 @@ int32_t mz_zip_reader_entry_save_file(void *handle, const char *path) {
         goto save_cleanup;
     }
 
-    err = mz_stream_os_open(stream, pathwfs, MZ_OPEN_MODE_CREATE);
+    /* Refuse to follow a symlink planted at the path after the check above */
+    err = mz_stream_os_open(stream, pathwfs, MZ_OPEN_MODE_CREATE | MZ_OPEN_MODE_NOFOLLOW);
 
     if (err == MZ_OK)
         err = mz_zip_reader_entry_save(reader, stream, mz_stream_write);

--- a/test/test_path.cc
+++ b/test/test_path.cc
@@ -168,3 +168,13 @@ TEST_P(symlink_target_base, os) {
     else
         EXPECT_NE(err, MZ_OK);
 }
+
+/* An overlong target must be validated in full rather than truncated to a safe prefix. The
+   traversal is placed past 1024 bytes so a fixed-size buffer would drop it and pass the check. */
+TEST(symlink_target_base, rejects_overlong_escaping_target) {
+    std::string target(1100, 'a');
+    target += "/../../outside/escaped.txt";
+
+    int32_t err = mz_path_is_symlink_target_safe("base/link", target.c_str(), "base");
+    EXPECT_NE(err, MZ_OK);
+}

--- a/test/test_reader.cc
+++ b/test/test_reader.cc
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <cstring>
 #include <string>
 
@@ -114,6 +115,90 @@ TEST_F(zip_reader_symlink_test, rejects_directory_entry_without_destination) {
 
     EXPECT_NE(mz_zip_reader_save_all(reader, nullptr), MZ_OK);
     EXPECT_NE(mz_os_is_dir(escaped_directory.c_str()), MZ_OK);
+}
+
+class zip_reader_confinement_test : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        char temp_path[] = "/tmp/minizip-confine-test-XXXXXX";
+        char *root = nullptr;
+
+        original_directory = getcwd(nullptr, 0);
+        ASSERT_NE(original_directory, nullptr);
+
+        root = mkdtemp(temp_path);
+        ASSERT_NE(root, nullptr);
+
+        root_path = root;
+        archive = root_path + "/archive.zip";
+        destination = root_path + "/destination";
+        outside = root_path + "/outside";
+
+        ASSERT_EQ(mkdir(destination.c_str(), 0755), 0);
+        ASSERT_EQ(mkdir(outside.c_str(), 0755), 0);
+    }
+
+    void TearDown() override {
+        if (reader) {
+            mz_zip_reader_close(reader);
+            mz_zip_reader_delete(&reader);
+        }
+        if (original_directory) {
+            chdir(original_directory);
+            free(original_directory);
+        }
+        /* Extraction may create a nested tree under the destination, so remove it recursively */
+        std::string command = "rm -rf " + root_path;
+        (void)system(command.c_str());
+    }
+
+    /* Write a single stored entry with the given name and contents */
+    void write_entry(const char *filename, const char *contents) {
+        mz_zip_file file_info;
+        void *writer = mz_zip_writer_create();
+        ASSERT_NE(writer, nullptr);
+
+        memset(&file_info, 0, sizeof(file_info));
+        file_info.filename = filename;
+        file_info.version_madeby = MZ_VERSION_MADEBY;
+        file_info.compression_method = MZ_COMPRESS_METHOD_STORE;
+        file_info.flag = MZ_ZIP_FLAG_UTF8;
+
+        ASSERT_EQ(mz_zip_writer_open_file(writer, archive.c_str(), 0, 0), MZ_OK);
+        ASSERT_EQ(mz_zip_writer_add_buffer(writer, (void *)contents, (int32_t)strlen(contents), &file_info), MZ_OK);
+        ASSERT_EQ(mz_zip_writer_close(writer), MZ_OK);
+        mz_zip_writer_delete(&writer);
+    }
+
+    void *reader = nullptr;
+    char *original_directory = nullptr;
+    std::string root_path;
+    std::string archive;
+    std::string destination;
+    std::string outside;
+};
+
+TEST_F(zip_reader_confinement_test, does_not_write_through_dangling_symlink) {
+    std::string planted = destination + "/link_name";
+    std::string escaped = outside + "/pwned.txt";
+
+    /* Pre-plant a dangling symlink whose target does not yet exist */
+    ASSERT_EQ(symlink(escaped.c_str(), planted.c_str()), 0);
+
+    write_entry("link_name", "escape");
+
+    reader = mz_zip_reader_create();
+    ASSERT_NE(reader, nullptr);
+    ASSERT_EQ(mz_zip_reader_open_file(reader, archive.c_str()), MZ_OK);
+    EXPECT_EQ(mz_zip_reader_save_all(reader, destination.c_str()), MZ_OK);
+
+    /* Extraction must not follow the symlink to write outside the destination */
+    EXPECT_NE(mz_os_file_exists(escaped.c_str()), MZ_OK);
+    EXPECT_NE(mz_os_is_symlink(planted.c_str()), MZ_OK);
+    EXPECT_EQ(mz_os_file_exists(planted.c_str()), MZ_OK);
+
+    unlink(planted.c_str());
+    unlink(archive.c_str());
 }
 #endif
 


### PR DESCRIPTION
Extraction could write outside the target directory through two symlink flaws.

`mz_zip_reader_entry_save_file` followed a pre-existing dangling symlink at the output path, because `stat` reports a dangling link as absent and the later `fopen` follows it. A symlink still present at the output path is now removed before the file is created, and the overwrite check consults `mz_os_is_symlink` so a callback still sees the link.

`mz_path_is_symlink_target_safe` validated a symlink target truncated to a fixed 1024-byte buffer while `mz_os_make_symlink` created the link from the full target. The buffers are now sized to the combined length of the parent and target, so validation and creation resolve the identical path.

Each new test fails against the current code and passes with the fix. The dangling-symlink case runs through `mz_zip_reader_save_all`, and the truncation case places its traversal past the old buffer boundary so a fixed-size buffer would drop it.

Closes #1027
Closes #1039