### PR TITLE
Fix stack overflow in mz_zip_reader_entry_get_hash

### DIFF
--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -538,8 +538,8 @@ int32_t mz_zip_reader_entry_get_hash(void *handle, uint16_t algorithm, uint8_t *
             err = mz_stream_read_uint16(file_extra_stream, &cur_digest_size);
         if ((err == MZ_OK) && (cur_algorithm == algorithm) && (cur_digest_size <= digest_size) &&
             (cur_digest_size <= MZ_HASH_MAX_SIZE)) {
-            /* Read hash digest */
-            if (mz_stream_read(file_extra_stream, digest, digest_size) == cur_digest_size)
+            /* Read only this record's validated digest size, not the caller-supplied length */
+            if (mz_stream_read(file_extra_stream, digest, cur_digest_size) == cur_digest_size)
                 return_err = MZ_OK;
             break;
         } else {


### PR DESCRIPTION
`mz_zip_reader_entry_get_hash` validated each hash record's own `digest_size` against `MZ_HASH_MAX_SIZE`, then read the caller-supplied `digest_size` parameter instead. That parameter is `reader->hash_digest_size`, taken verbatim from the first hash extra field and never bounds-checked.

An entry with two `MZ_ZIP_EXTENSION_HASH` (`0x1a51`) records, the first oversized to poison the stored digest size and the second small enough to pass the per-record check, could copy up to 65535 bytes into the 256-byte `expected_hash` stack buffer in `mz_zip_reader_entry_close`, corrupting the stack and enabling control-flow hijack.

The read now uses the validated `cur_digest_size`, which the same guard already constrains to at most `MZ_HASH_MAX_SIZE` and to the destination buffer.

Closes #1023