### PR TITLE
Strip setuid and setgid bits when extracting

### DIFF
--- a/mz_os_posix.c
+++ b/mz_os_posix.c
@@ -317,7 +317,10 @@ int32_t mz_os_get_file_attribs(const char *path, uint32_t *attributes) {
 int32_t mz_os_set_file_attribs(const char *path, uint32_t attributes) {
     int32_t err = MZ_OK;
 
-    if (chmod(path, (mode_t)attributes) == -1)
+    /* Strip setuid, setgid, and sticky bits so a crafted archive cannot create a setuid file */
+    mode_t mode = (mode_t)attributes & ~(mode_t)(S_ISUID | S_ISGID | S_ISVTX);
+
+    if (chmod(path, mode) == -1)
         err = MZ_INTERNAL_ERROR;
 
     return err;

--- a/test/test_reader.cc
+++ b/test/test_reader.cc
@@ -16,11 +16,15 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
 #include <string>
 
-#if !defined(_WIN32) && defined(HAVE_SYMLINK)
+#if !defined(_WIN32)
 #  include <sys/stat.h>
 #  include <unistd.h>
+#endif
+
+#if !defined(_WIN32) && defined(HAVE_SYMLINK)
 
 class zip_reader_symlink_test : public ::testing::Test {
   protected:
@@ -110,5 +114,50 @@ TEST_F(zip_reader_symlink_test, rejects_directory_entry_without_destination) {
 
     EXPECT_NE(mz_zip_reader_save_all(reader, nullptr), MZ_OK);
     EXPECT_NE(mz_os_is_dir(escaped_directory.c_str()), MZ_OK);
+}
+#endif
+
+#if !defined(_WIN32)
+/* A crafted archive must not produce a setuid file on extraction */
+TEST(zip_reader_attribs, strips_setuid_bits) {
+    char destination[] = "/tmp/minizip-attribs-test-XXXXXX";
+    ASSERT_NE(mkdtemp(destination), nullptr);
+
+    std::string archive = std::string(destination) + "/archive.zip";
+    std::string extracted = std::string(destination) + "/setuid_entry";
+
+    mz_zip_file file_info;
+    memset(&file_info, 0, sizeof(file_info));
+    file_info.filename = "setuid_entry";
+    file_info.version_madeby = (MZ_HOST_SYSTEM_UNIX << 8) | MZ_VERSION_MADEBY_ZIP_VERSION;
+    file_info.compression_method = MZ_COMPRESS_METHOD_STORE;
+    file_info.flag = MZ_ZIP_FLAG_UTF8;
+    file_info.external_fa = (uint32_t)((S_ISUID | S_ISGID | S_ISVTX | 0755) << 16);
+
+    void *writer = mz_zip_writer_create();
+    ASSERT_NE(writer, nullptr);
+    ASSERT_EQ(mz_zip_writer_open_file(writer, archive.c_str(), 0, 0), MZ_OK);
+    ASSERT_EQ(mz_zip_writer_add_buffer(writer, (void *)"data", 4, &file_info), MZ_OK);
+    ASSERT_EQ(mz_zip_writer_close(writer), MZ_OK);
+    mz_zip_writer_delete(&writer);
+
+    void *reader = mz_zip_reader_create();
+    ASSERT_NE(reader, nullptr);
+    ASSERT_EQ(mz_zip_reader_open_file(reader, archive.c_str()), MZ_OK);
+    EXPECT_EQ(mz_zip_reader_save_all(reader, destination), MZ_OK);
+    mz_zip_reader_close(reader);
+    mz_zip_reader_delete(&reader);
+
+    struct stat entry_stat;
+    memset(&entry_stat, 0, sizeof(entry_stat));
+    ASSERT_EQ(stat(extracted.c_str(), &entry_stat), 0);
+
+    /* The special bits are stripped while the ordinary permission bits are kept */
+    EXPECT_EQ(entry_stat.st_mode & (S_ISUID | S_ISGID | S_ISVTX), 0u);
+    EXPECT_EQ(entry_stat.st_mode & 0777, 0755u);
+
+    unlink(extracted.c_str());
+    unlink(archive.c_str());
+    rmdir(destination);
 }
 #endif


### PR DESCRIPTION
`mz_zip_reader_entry_save_file` applied an entry's Unix mode from `external_fa` through `mz_zip_attrib_convert` and `chmod` without filtering the special permission bits. A crafted entry with `external_fa` set to `(S_ISUID | 0755) << 16` produced a setuid file regardless of the extracting process's umask. When a privileged process extracts the archive, the result is a setuid-root binary an unprivileged local user can execute, a local privilege escalation.

`mz_os_set_file_attribs` on POSIX now masks `S_ISUID`, `S_ISGID`, and `S_ISVTX` before `chmod`. This is the single point where extracted mode bits reach the filesystem, and it is only used on the extraction path, so ordinary permission bits are preserved while the dangerous ones are dropped. This matches tar's default (`--no-same-permissions` when not run as root).

The regression test extracts an entry whose mode carries all three special bits plus `0755` and asserts the extracted file keeps `0755` with none of the special bits set.

Closes #1026