### PR TITLE
Confine absolute entry names on extraction

### DIFF
--- a/mz_os.c
+++ b/mz_os.c
@@ -42,6 +42,22 @@ int32_t mz_path_combine(char *path, const char *join, int32_t max_path) {
     return MZ_OK;
 }
 
+int32_t mz_path_combine_safe(char *path, const char *join, int32_t max_path) {
+    if (!path || !join || !max_path)
+        return MZ_PARAM_ERROR;
+
+    /* Drop a drive letter and any leading separators so an absolute join stays under path */
+    if (*join != 0 && join[1] == ':')
+        join += 2;
+    while (mz_os_is_dir_separator(*join))
+        join += 1;
+
+    if (*join == 0)
+        return MZ_EXIST_ERROR;
+
+    return mz_path_combine(path, join, max_path);
+}
+
 int32_t mz_path_append_slash(char *path, int32_t max_path, char slash) {
     int32_t path_len = (int32_t)strlen(path);
     if ((path_len + 2) >= max_path)

--- a/mz_os.h
+++ b/mz_os.h
@@ -73,6 +73,9 @@ extern "C" {
 int32_t mz_path_combine(char *path, const char *join, int32_t max_path);
 /* Combines two paths */
 
+int32_t mz_path_combine_safe(char *path, const char *join, int32_t max_path);
+/* Combines two paths, forcing join to stay relative so it cannot escape path */
+
 int32_t mz_path_append_slash(char *path, int32_t max_path, char slash);
 /* Appends a path slash on to the end of the path */
 

--- a/mz_zip_rw.c
+++ b/mz_zip_rw.c
@@ -950,7 +950,10 @@ int32_t mz_zip_reader_save_all(void *handle, const char *destination_dir) {
         if (destination_dir)
             mz_path_combine(path, destination_dir, resolved_name_size);
 
-        mz_path_combine(path, resolved_name, resolved_name_size);
+        /* Force the entry name to stay under the destination so an absolute path cannot escape */
+        err = mz_path_combine_safe(path, resolved_name, resolved_name_size);
+        if (err != MZ_OK)
+            break;
 
         /* Save file to disk */
         err = mz_zip_reader_entry_save_file(reader, path);

--- a/test/test_path.cc
+++ b/test/test_path.cc
@@ -68,6 +68,59 @@ TEST_P(path_resolve, os) {
     EXPECT_STREQ(output, expected_path.c_str());
 }
 
+struct combine_safe_param {
+    const char *base;
+    const char *join;
+    const char *expected_path; /* nullptr when the join is expected to be rejected */
+
+    friend std::ostream &operator<<(std::ostream &os, const combine_safe_param &param) {
+        return os << "base: " << param.base << " join: " << param.join;
+    }
+};
+
+constexpr combine_safe_param combine_safe_tests[] = {
+    /* Relative joins are combined unchanged */
+    {"dest",     "sub\\file",   "dest\\sub\\file"},
+    /* Leading separators and drive letters are stripped so the join stays relative */
+    {"dest", "\\etc\\passwd", "dest\\etc\\passwd"},
+    {"dest",       "\\\\\\a",           "dest\\a"},
+    {"dest",      "c:\\evil",        "dest\\evil"},
+    /* An empty base keeps the stripped join */
+    {    "",      "\\abs\\f",            "abs\\f"},
+    /* A join that strips down to nothing is rejected */
+    {"dest",            "\\",             nullptr},
+    {"dest",              "",             nullptr},
+};
+
+class path_combine_safe : public ::testing::TestWithParam<combine_safe_param> {};
+
+INSTANTIATE_TEST_SUITE_P(os, path_combine_safe, testing::ValuesIn(combine_safe_tests));
+
+TEST_P(path_combine_safe, os) {
+    const auto &param = GetParam();
+    std::string base = param.base;
+    std::string join = param.join;
+    std::string expected_path = param.expected_path ? param.expected_path : "";
+
+    if (!mz_os_is_dir_separator('\\')) {
+        std::replace(base.begin(), base.end(), '\\', '/');
+        std::replace(join.begin(), join.end(), '\\', '/');
+        std::replace(expected_path.begin(), expected_path.end(), '\\', '/');
+    }
+
+    char output[256];
+    memset(output, 0, sizeof(output));
+    strncpy(output, base.c_str(), sizeof(output) - 1);
+
+    int32_t err = mz_path_combine_safe(output, join.c_str(), sizeof(output));
+    if (param.expected_path) {
+        EXPECT_EQ(err, MZ_OK);
+        EXPECT_STREQ(output, expected_path.c_str());
+    } else {
+        EXPECT_NE(err, MZ_OK);
+    }
+}
+
 struct symlink_base_param {
     const char *link_path;
     const char *target;


### PR DESCRIPTION
An archive entry whose name is an absolute path (for example `/etc/cron.d/evil`) was written to that literal path when `mz_zip_reader_save_all` was called with `destination_dir == NULL`, which is the default `minizip -x` behavior when `-d` is not given. `mz_path_resolve` normalizes `.` and `..` but preserves a leading separator, so the absolute name reached the filesystem unchanged.

The stripping belongs neither inline in `mz_zip_reader_save_all` nor in `mz_path_combine` itself, `save_all` also calls `mz_path_combine` one line earlier with the trusted `destination_dir`, and stripping there would mangle a legitimate absolute destination such as `-d /home/user/out`.

This adds `mz_path_combine_safe`, which drops a drive letter and any leading separators so the joined name is forced to stay under `path`, and uses it only for the untrusted entry name. The plain `mz_path_combine` continues to join the destination directory, so absolute destinations still work.

A unit test covers `mz_path_combine_safe` directly: relative joins are combined unchanged, leading separators and drive letters are stripped, and a join that reduces to nothing is rejected.

Closes #1025
Closes #1038